### PR TITLE
Fix flake8 warning in test_model

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from reticulum_openapi.model import dataclass_to_json, dataclass_from_json
 
+
 @dataclass
 class Item:
     name: str


### PR DESCRIPTION
## Summary
- address flake8 E302 warning in `tests/test_model.py`

## Testing
- `flake8 tests/test_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c6898b1083258ef5e481e30e82c5