### PR TITLE
Fix flake8 errors in tests package init

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,6 @@
-import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+"""Test package configuration."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))


### PR DESCRIPTION
## Summary
- clean up `tests/__init__.py` to satisfy flake8

## Testing
- `flake8 reticulum_openapi examples tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852cf4d6cc083258b2cb5aeb856bdd1