### PR TITLE
Add stop coroutine to service

### DIFF
--- a/examples/EmergencyManagement/Server/server_emergency.py
+++ b/examples/EmergencyManagement/Server/server_emergency.py
@@ -24,7 +24,12 @@ async def main():
     svc.add_route("PatchEvent", evc.PatchEvent, Event)
     svc.add_route("RetrieveEvent", evc.RetrieveEvent)
     svc.announce()
-    await svc.start()
+    service_task = asyncio.create_task(svc.start())
+    try:
+        await asyncio.sleep(30)  # Run for 30 seconds then stop
+    finally:
+        await svc.stop()
+        await service_task
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `stop` coroutine to `LXMFService`
- call new `stop` method in EmergencyManagement server example

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6852d36d52b4832582c47d5a7d1689d9