### PR TITLE
Add pytest-asyncio support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,10 @@ dependencies = [
     "SQLAlchemy",
     "jsonschema"
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "flake8"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ LXMF
 SQLAlchemy
 jsonschema
 pytest
+pytest-asyncio
 flake8


### PR DESCRIPTION
## Summary
- include `pytest-asyncio` for async test support
- expose dev dependencies through optional extras

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852fa4a14248325ac7bab30189302aa