### PR TITLE
Increase test coverage

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,74 @@
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import Mock
+import pytest
+
+from reticulum_openapi import client as client_module
+
+@dataclass
+class Sample:
+    text: str
+
+@pytest.mark.asyncio
+async def test_send_command_receives_response(monkeypatch):
+    loop = asyncio.get_running_loop()
+    cli = client_module.LXMFClient.__new__(client_module.LXMFClient)
+    cli._loop = loop
+    cli.router = SimpleNamespace(handle_outbound=lambda msg: None)
+    cli.source_identity = object()
+    cli._futures = {}
+    cli.auth_token = None
+    cli.timeout = 0.2
+
+    monkeypatch.setattr(client_module.RNS.Transport, "has_path", lambda dest: True)
+    monkeypatch.setattr(client_module.RNS.Transport, "request_path", lambda dest: None)
+    monkeypatch.setattr(client_module.RNS.Identity, "recall", lambda h, create=False: object())
+
+    class FakeDestination:
+        OUT = object()
+        SINGLE = object()
+        def __init__(self, *a, **k):
+            pass
+    monkeypatch.setattr(client_module.RNS, "Destination", FakeDestination)
+
+    class FakeLXMessage:
+        def __init__(self, dest, src, content, title):
+            self.dest = dest
+            self.src = src
+            self.content = content
+            self.title = title
+    monkeypatch.setattr(client_module.LXMF, "LXMessage", FakeLXMessage)
+
+    async def run_cmd():
+        return await cli.send_command("aa", "CMD", Sample(text="hi"))
+
+    task = asyncio.create_task(run_cmd())
+    await asyncio.sleep(0.01)
+    cli._callback(SimpleNamespace(title="CMD_response", content=b"ok"))
+    result = await task
+    assert result == b"ok"
+
+@pytest.mark.asyncio
+async def test_send_command_timeout(monkeypatch):
+    loop = asyncio.get_running_loop()
+    cli = client_module.LXMFClient.__new__(client_module.LXMFClient)
+    cli._loop = loop
+    cli.router = SimpleNamespace(handle_outbound=lambda msg: None)
+    cli.source_identity = object()
+    cli._futures = {}
+    cli.auth_token = None
+    cli.timeout = 0.01
+
+    monkeypatch.setattr(client_module.RNS.Transport, "has_path", lambda dest: True)
+    monkeypatch.setattr(client_module.RNS.Identity, "recall", lambda h, create=False: object())
+    class FakeDestination:
+        OUT = object()
+        SINGLE = object()
+        def __init__(self, *a, **k):
+            pass
+    monkeypatch.setattr(client_module.RNS, "Destination", FakeDestination)
+    monkeypatch.setattr(client_module.LXMF, "LXMessage", lambda *a, **k: None)
+
+    with pytest.raises(TimeoutError):
+        await cli.send_command("aa", "CMD")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,47 @@
+import pytest
+import asyncio
+
+from reticulum_openapi import controller as c
+
+@pytest.mark.asyncio
+async def test_handle_exceptions_success():
+    @c.handle_exceptions
+    async def handler(self, x):
+        return x * 2
+
+    result = await handler(object(), 3)
+    assert result == 6
+
+@pytest.mark.asyncio
+async def test_handle_exceptions_apierror():
+    @c.handle_exceptions
+    async def handler(self):
+        raise c.APIException("bad", 400)
+
+    result = await handler(object())
+    assert result == {"error": "bad", "code": 400}
+
+@pytest.mark.asyncio
+async def test_handle_exceptions_generic():
+    @c.handle_exceptions
+    async def handler(self):
+        raise ValueError("boom")
+
+    result = await handler(object())
+    assert result == {"error": "InternalServerError", "code": 500}
+
+@pytest.mark.asyncio
+async def test_run_business_logic(monkeypatch):
+    ctrl = c.Controller()
+    async def logic(a, b):
+        return a + b
+    result = await ctrl.run_business_logic(logic, 2, 3)
+    assert result == 5
+
+@pytest.mark.asyncio
+async def test_run_business_logic_error():
+    ctrl = c.Controller()
+    async def logic():
+        raise c.APIException("fail", 401)
+    result = await ctrl.run_business_logic(logic)
+    assert result == {"error": "fail", "code": 401}

--- a/tests/test_service_extra.py
+++ b/tests/test_service_extra.py
@@ -1,0 +1,118 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+import pytest
+
+from reticulum_openapi import service as service_module
+from dataclasses import dataclass
+
+@dataclass
+class Item:
+    name: str
+
+@pytest.mark.asyncio
+async def test_send_message_calls_send(monkeypatch):
+    svc = service_module.LXMFService.__new__(service_module.LXMFService)
+    svc._loop = asyncio.get_running_loop()
+    svc._send_lxmf = Mock()
+    dest_identity = object()
+    call_count = {"n": 0}
+
+    def has_path(dest):
+        call_count["n"] += 1
+        return call_count["n"] > 1
+
+    async def fast_sleep(_):
+        pass
+
+    monkeypatch.setattr(service_module.asyncio, "sleep", fast_sleep)
+    monkeypatch.setattr(service_module.RNS.Transport, "has_path", has_path)
+    monkeypatch.setattr(service_module.RNS.Transport, "request_path", lambda d: None)
+
+    def recall(dest, create=False):
+        if create:
+            return dest_identity
+        return None
+
+    monkeypatch.setattr(service_module.RNS.Identity, "recall", recall)
+    await svc.send_message("aa", "CMD", Item(name="x"))
+    svc._send_lxmf.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_send_lxmf_uses_router(monkeypatch):
+    svc = service_module.LXMFService.__new__(service_module.LXMFService)
+    send_mock = Mock()
+    svc.router = SimpleNamespace(handle_outbound=send_mock)
+    svc.source_identity = object()
+    class FakeDestination:
+        OUT = object()
+        SINGLE = object()
+        def __init__(self, *a, **k):
+            pass
+    class FakeLXMessage:
+        def __init__(self, dest, src, content, title):
+            self.dest = dest
+            self.src = src
+            self.content = content
+            self.title = title
+    monkeypatch.setattr(service_module.RNS, "Destination", FakeDestination)
+    monkeypatch.setattr(service_module.LXMF, "LXMessage", FakeLXMessage)
+    svc._send_lxmf(object(), "CMD", b"data")
+    send_mock.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_announce_logs(monkeypatch):
+    svc = service_module.LXMFService.__new__(service_module.LXMFService)
+    ann_mock = Mock()
+    svc.router = SimpleNamespace(announce=ann_mock)
+    svc.source_identity = SimpleNamespace(hash=b"x")
+    monkeypatch.setattr(service_module.RNS, "prettyhexrep", lambda x: "x")
+    monkeypatch.setattr(service_module.RNS, "log", lambda *a, **k: None)
+    svc.announce()
+    ann_mock.assert_called_once_with(svc.source_identity.hash)
+
+@pytest.mark.asyncio
+async def test_start_and_stop(monkeypatch):
+    svc = service_module.LXMFService.__new__(service_module.LXMFService)
+    svc.router = SimpleNamespace(exit_handler=Mock())
+    svc._loop = asyncio.get_running_loop()
+    monkeypatch.setattr(service_module.RNS, "log", lambda *a, **k: None)
+    task = asyncio.create_task(svc.start())
+    await asyncio.sleep(0.05)
+    await svc.stop()
+    assert svc._start_task is None
+
+@pytest.mark.asyncio
+async def test_init_and_add_route(monkeypatch):
+    class FakeReticulum:
+        storagepath = '/tmp'
+        def __init__(self, config_path=None):
+            pass
+    class FakeIdentity:
+        def __init__(self):
+            self.hash = b'h'
+    class FakeRNS:
+        Reticulum = FakeReticulum
+        Identity = FakeIdentity
+        @staticmethod
+        def log(*a, **k):
+            pass
+        @staticmethod
+        def prettyhexrep(x):
+            return 'h'
+    class FakeLXMRouter:
+        def __init__(self, storagepath=None):
+            self.storagepath = storagepath
+        def register_delivery_callback(self, cb):
+            self.cb = cb
+        def register_delivery_identity(self, ident, display_name=None, stamp_cost=0):
+            return ident
+    class FakeLXMF:
+        LXMRouter = FakeLXMRouter
+        LXMessage = object
+    monkeypatch.setattr(service_module, 'RNS', FakeRNS)
+    monkeypatch.setattr(service_module, 'LXMF', FakeLXMF)
+    svc = service_module.LXMFService()
+    assert isinstance(svc.router, FakeLXMRouter)
+    svc.add_route('PING', lambda: None)
+    assert 'PING' in svc._routes


### PR DESCRIPTION
## Summary
- add tests for LXMFClient behavior
- add tests for exception handling utilities
- expand LXMFService tests for send_message and routing

## Testing
- `pytest --quiet`
- `coverage run --source=reticulum_openapi -m pytest --disable-warnings --quiet && coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_68531925feec83259d069a57c403c6a4