### PR TITLE
Fix flake8 warnings in tests

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,14 +1,15 @@
 import asyncio
 from dataclasses import dataclass
 from types import SimpleNamespace
-from unittest.mock import Mock
 import pytest
 
 from reticulum_openapi import client as client_module
 
+
 @dataclass
 class Sample:
     text: str
+
 
 @pytest.mark.asyncio
 async def test_send_command_receives_response(monkeypatch):
@@ -28,11 +29,13 @@ async def test_send_command_receives_response(monkeypatch):
     class FakeDestination:
         OUT = object()
         SINGLE = object()
+
         def __init__(self, *a, **k):
             pass
     monkeypatch.setattr(client_module.RNS, "Destination", FakeDestination)
 
     class FakeLXMessage:
+
         def __init__(self, dest, src, content, title):
             self.dest = dest
             self.src = src
@@ -49,6 +52,7 @@ async def test_send_command_receives_response(monkeypatch):
     result = await task
     assert result == b"ok"
 
+
 @pytest.mark.asyncio
 async def test_send_command_timeout(monkeypatch):
     loop = asyncio.get_running_loop()
@@ -62,9 +66,11 @@ async def test_send_command_timeout(monkeypatch):
 
     monkeypatch.setattr(client_module.RNS.Transport, "has_path", lambda dest: True)
     monkeypatch.setattr(client_module.RNS.Identity, "recall", lambda h, create=False: object())
+
     class FakeDestination:
         OUT = object()
         SINGLE = object()
+
         def __init__(self, *a, **k):
             pass
     monkeypatch.setattr(client_module.RNS, "Destination", FakeDestination)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,7 +1,7 @@
 import pytest
-import asyncio
 
 from reticulum_openapi import controller as c
+
 
 @pytest.mark.asyncio
 async def test_handle_exceptions_success():
@@ -12,6 +12,7 @@ async def test_handle_exceptions_success():
     result = await handler(object(), 3)
     assert result == 6
 
+
 @pytest.mark.asyncio
 async def test_handle_exceptions_apierror():
     @c.handle_exceptions
@@ -20,6 +21,7 @@ async def test_handle_exceptions_apierror():
 
     result = await handler(object())
     assert result == {"error": "bad", "code": 400}
+
 
 @pytest.mark.asyncio
 async def test_handle_exceptions_generic():
@@ -30,17 +32,21 @@ async def test_handle_exceptions_generic():
     result = await handler(object())
     assert result == {"error": "InternalServerError", "code": 500}
 
+
 @pytest.mark.asyncio
 async def test_run_business_logic(monkeypatch):
     ctrl = c.Controller()
+
     async def logic(a, b):
         return a + b
     result = await ctrl.run_business_logic(logic, 2, 3)
     assert result == 5
 
+
 @pytest.mark.asyncio
 async def test_run_business_logic_error():
     ctrl = c.Controller()
+
     async def logic():
         raise c.APIException("fail", 401)
     result = await ctrl.run_business_logic(logic)

--- a/tests/test_service_extra.py
+++ b/tests/test_service_extra.py
@@ -6,9 +6,11 @@ import pytest
 from reticulum_openapi import service as service_module
 from dataclasses import dataclass
 
+
 @dataclass
 class Item:
     name: str
+
 
 @pytest.mark.asyncio
 async def test_send_message_calls_send(monkeypatch):
@@ -38,18 +40,23 @@ async def test_send_message_calls_send(monkeypatch):
     await svc.send_message("aa", "CMD", Item(name="x"))
     svc._send_lxmf.assert_called_once()
 
+
 @pytest.mark.asyncio
 async def test_send_lxmf_uses_router(monkeypatch):
     svc = service_module.LXMFService.__new__(service_module.LXMFService)
     send_mock = Mock()
     svc.router = SimpleNamespace(handle_outbound=send_mock)
     svc.source_identity = object()
+
     class FakeDestination:
         OUT = object()
         SINGLE = object()
+
         def __init__(self, *a, **k):
             pass
+
     class FakeLXMessage:
+
         def __init__(self, dest, src, content, title):
             self.dest = dest
             self.src = src
@@ -59,6 +66,7 @@ async def test_send_lxmf_uses_router(monkeypatch):
     monkeypatch.setattr(service_module.LXMF, "LXMessage", FakeLXMessage)
     svc._send_lxmf(object(), "CMD", b"data")
     send_mock.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_announce_logs(monkeypatch):
@@ -71,42 +79,56 @@ async def test_announce_logs(monkeypatch):
     svc.announce()
     ann_mock.assert_called_once_with(svc.source_identity.hash)
 
+
 @pytest.mark.asyncio
 async def test_start_and_stop(monkeypatch):
     svc = service_module.LXMFService.__new__(service_module.LXMFService)
     svc.router = SimpleNamespace(exit_handler=Mock())
     svc._loop = asyncio.get_running_loop()
     monkeypatch.setattr(service_module.RNS, "log", lambda *a, **k: None)
-    task = asyncio.create_task(svc.start())
+    asyncio.create_task(svc.start())
     await asyncio.sleep(0.05)
     await svc.stop()
     assert svc._start_task is None
+
 
 @pytest.mark.asyncio
 async def test_init_and_add_route(monkeypatch):
     class FakeReticulum:
         storagepath = '/tmp'
+
         def __init__(self, config_path=None):
             pass
+
     class FakeIdentity:
+
         def __init__(self):
+
             self.hash = b'h'
+
     class FakeRNS:
         Reticulum = FakeReticulum
         Identity = FakeIdentity
+
         @staticmethod
         def log(*a, **k):
             pass
+
         @staticmethod
         def prettyhexrep(x):
             return 'h'
+
     class FakeLXMRouter:
+
         def __init__(self, storagepath=None):
             self.storagepath = storagepath
+
         def register_delivery_callback(self, cb):
             self.cb = cb
+
         def register_delivery_identity(self, ident, display_name=None, stamp_cost=0):
             return ident
+
     class FakeLXMF:
         LXMRouter = FakeLXMRouter
         LXMessage = object


### PR DESCRIPTION
## Summary
- clean up unused imports and spacing in tests
- remove unused variables
- ensure nested definitions have preceding blank lines

## Testing
- `flake8 tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685321e03f80832581e5029fc7dcdb93