### PR TITLE
Use PUT in example update operations

### DIFF
--- a/examples/EmergencyManagement/API/EmergencyActionMessageManagement-OAS.yaml
+++ b/examples/EmergencyManagement/API/EmergencyActionMessageManagement-OAS.yaml
@@ -58,18 +58,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/200EmergencyActionMessage_get'
-    patch:
+    put:
       x-scope: public
       tags:
        - EmergencyActionMessage
       description: >-
       summary: Updates an existing EmergencyActionMessage record.
-      operationId: PatchEmergencyActionMessage
+      operationId: PutEmergencyActionMessage
       requestBody:
         $ref: '#/components/requestBodies/EmergencyActionMessage'
       responses:
         '200':
-          $ref: '#/components/responses/200EmergencyActionMessage_patch'
+          $ref: '#/components/responses/200EmergencyActionMessage_put'
   /Event/EmergencyActionMessage:
     post:
       x-scope: public
@@ -106,18 +106,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/200Event_get'
-    patch:
+    put:
       x-scope: public
       tags:
        - Event
       description: >-
       summary: Updates an existing Event record.
-      operationId: PatchEvent
+      operationId: PutEvent
       requestBody:
         $ref: '#/components/requestBodies/Event'
       responses:
         '200':
-          $ref: '#/components/responses/200Event_patch'
+          $ref: '#/components/responses/200Event_put'
   /EmergencyActionMessage/{id}:
     get:
       x-scope: public
@@ -298,7 +298,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/EmergencyActionMessage'
-    200EmergencyActionMessage_patch:
+    200EmergencyActionMessage_put:
       description: Success
       content:
         application/json:
@@ -316,7 +316,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Event'
-    200Event_patch:
+    200Event_put:
       description: Success
       content:
         application/json:

--- a/examples/EmergencyManagement/Server/controllers_emergency.py
+++ b/examples/EmergencyManagement/Server/controllers_emergency.py
@@ -30,8 +30,8 @@ class EmergencyController(Controller):
         return items
 
     @handle_exceptions
-    async def PatchEmergencyActionMessage(self, req: EmergencyActionMessage):
-        self.logger.info(f"PatchEAM: {req}")
+    async def PutEmergencyActionMessage(self, req: EmergencyActionMessage):
+        self.logger.info(f"PutEAM: {req}")
         async with async_session() as session:
             updated = await EmergencyActionMessage.update(session, req.callsign, **asdict(req))
         return updated
@@ -67,8 +67,8 @@ class EventController(Controller):
         return events
 
     @handle_exceptions
-    async def PatchEvent(self, req: Event):
-        self.logger.info(f"PatchEvent: {req}")
+    async def PutEvent(self, req: Event):
+        self.logger.info(f"PutEvent: {req}")
         async with async_session() as session:
             updated = await Event.update(session, req.uid, **asdict(req))
         return updated

--- a/examples/EmergencyManagement/Server/service_emergency.py
+++ b/examples/EmergencyManagement/Server/service_emergency.py
@@ -26,8 +26,8 @@ class EmergencyService(LXMFService):
         self.add_route("DeleteEmergencyActionMessage", eamc.DeleteEmergencyActionMessage)
         self.add_route("ListEmergencyActionMessage", eamc.ListEmergencyActionMessage)
         self.add_route(
-            "PatchEmergencyActionMessage",
-            eamc.PatchEmergencyActionMessage,
+            "PutEmergencyActionMessage",
+            eamc.PutEmergencyActionMessage,
             EmergencyActionMessage,
         )
         self.add_route("RetrieveEmergencyActionMessage", eamc.RetrieveEmergencyActionMessage)
@@ -35,5 +35,5 @@ class EmergencyService(LXMFService):
         self.add_route("CreateEvent", evc.CreateEvent, Event)
         self.add_route("DeleteEvent", evc.DeleteEvent)
         self.add_route("ListEvent", evc.ListEvent)
-        self.add_route("PatchEvent", evc.PatchEvent, Event)
+        self.add_route("PutEvent", evc.PutEvent, Event)
         self.add_route("RetrieveEvent", evc.RetrieveEvent)


### PR DESCRIPTION
## Summary
- switch update methods in the emergency example to use `PUT`
- rename update routes and operation IDs
- update controller methods accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532570682c83259ff659fde106ab88