### PR TITLE
Allow optional fields in example models

### DIFF
--- a/examples/EmergencyManagement/API/EmergencyActionMessageManagement-OAS.yaml
+++ b/examples/EmergencyManagement/API/EmergencyActionMessageManagement-OAS.yaml
@@ -140,7 +140,7 @@ components:
             callsign:
               type: string
               description: >-
-                use TAK or HAM callsign 
+                use TAK or HAM callsign
             groupName:
               type: string
               description: >-
@@ -186,6 +186,8 @@ components:
                 Yellow – No immediate threats, but NOT in a secure area
                 Green – No immediate threats and currently in a secure area
               $ref: '#/components/schemas/EAMStatus'
+          required:
+            - callsign
     Event:
       allOf:
         - type: object
@@ -228,6 +230,8 @@ components:
               nullable: true
               type: string
               x-reference: '#/components/schemas/Point'
+          required:
+            - uid
     Point:
       allOf:
         - type: object

--- a/examples/EmergencyManagement/README.md
+++ b/examples/EmergencyManagement/README.md
@@ -7,6 +7,10 @@ The example models an emergency management system with two main resources:
 * **EmergencyActionMessage** – a status report for a callsign
 * **Event** – a wrapper that may contain one or more emergency action messages
 
+The dataclass models treat `callsign` (for EmergencyActionMessage) and `uid`
+(for Event) as **required** fields. All other properties are optional and may be
+omitted or `null` when encoding the JSON payload.
+
 The API contract is described in [`API/EmergencyActionMessageManagement-OAS.yaml`](API/EmergencyActionMessageManagement-OAS.yaml).
 
 ## Components

--- a/examples/EmergencyManagement/Server/models_emergency.py
+++ b/examples/EmergencyManagement/Server/models_emergency.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from typing import Optional
+
 from reticulum_openapi.model import BaseModel
 from sqlalchemy.orm import declarative_base
 from sqlalchemy import Column, Integer, String, JSON
@@ -9,30 +11,30 @@ Base = declarative_base()
 class EmergencyActionMessageORM(Base):
     __tablename__ = "emergency_action_messages"
     callsign = Column(String, primary_key=True)
-    groupName = Column(String)
-    securityStatus = Column(String)
-    securityCapability = Column(String)
-    preparednessStatus = Column(String)
-    medicalStatus = Column(String)
-    mobilityStatus = Column(String)
-    commsStatus = Column(String)
-    commsMethod = Column(String)
+    groupName = Column(String, nullable=True)
+    securityStatus = Column(String, nullable=True)
+    securityCapability = Column(String, nullable=True)
+    preparednessStatus = Column(String, nullable=True)
+    medicalStatus = Column(String, nullable=True)
+    mobilityStatus = Column(String, nullable=True)
+    commsStatus = Column(String, nullable=True)
+    commsMethod = Column(String, nullable=True)
 
 
 class EventORM(Base):
     __tablename__ = "events"
     uid = Column(Integer, primary_key=True)
-    how = Column(String)
-    version = Column(Integer)
-    time = Column(Integer)
-    type = Column(String)
-    stale = Column(String)
-    start = Column(String)
-    access = Column(String)
-    opex = Column(Integer)
-    qos = Column(Integer)
-    detail = Column(JSON)
-    point = Column(JSON)
+    how = Column(String, nullable=True)
+    version = Column(Integer, nullable=True)
+    time = Column(Integer, nullable=True)
+    type = Column(String, nullable=True)
+    stale = Column(String, nullable=True)
+    start = Column(String, nullable=True)
+    access = Column(String, nullable=True)
+    opex = Column(Integer, nullable=True)
+    qos = Column(Integer, nullable=True)
+    detail = Column(JSON, nullable=True)
+    point = Column(JSON, nullable=True)
 
 
 class EAMStatus(str):
@@ -44,43 +46,43 @@ class EAMStatus(str):
 @dataclass
 class EmergencyActionMessage(BaseModel):
     callsign: str
-    groupName: str
-    securityStatus: EAMStatus
-    securityCapability: EAMStatus
-    preparednessStatus: EAMStatus
-    medicalStatus: EAMStatus
-    mobilityStatus: EAMStatus
-    commsStatus: EAMStatus
-    commsMethod: str
+    groupName: Optional[str] = None
+    securityStatus: Optional[EAMStatus] = None
+    securityCapability: Optional[EAMStatus] = None
+    preparednessStatus: Optional[EAMStatus] = None
+    medicalStatus: Optional[EAMStatus] = None
+    mobilityStatus: Optional[EAMStatus] = None
+    commsStatus: Optional[EAMStatus] = None
+    commsMethod: Optional[str] = None
     __orm_model__ = EmergencyActionMessageORM
 
 
 @dataclass
 class Detail(BaseModel):
-    emergencyActionMessage: EmergencyActionMessage
+    emergencyActionMessage: Optional[EmergencyActionMessage] = None
 
 
 @dataclass
 class Point(BaseModel):
-    lat: float
-    lon: float
-    ce: float
-    le: float
-    hae: float
+    lat: Optional[float] = None
+    lon: Optional[float] = None
+    ce: Optional[float] = None
+    le: Optional[float] = None
+    hae: Optional[float] = None
 
 
 @dataclass
 class Event(BaseModel):
     uid: int
-    how: str
-    version: int
-    time: int
-    type: str
-    stale: str
-    start: str
-    access: str
-    opex: int
-    qos: int
-    detail: Detail
-    point: Point
+    how: Optional[str] = None
+    version: Optional[int] = None
+    time: Optional[int] = None
+    type: Optional[str] = None
+    stale: Optional[str] = None
+    start: Optional[str] = None
+    access: Optional[str] = None
+    opex: Optional[int] = None
+    qos: Optional[int] = None
+    detail: Optional[Detail] = None
+    point: Optional[Point] = None
     __orm_model__ = EventORM


### PR DESCRIPTION
## Summary
- relax example database columns so most fields are nullable
- update EmergencyActionMessage and Event dataclasses to use Optional fields
- mark required properties in the OpenAPI example
- document which fields are required in the example README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for RNS and SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6853266c3fb88325a044381f66044832