### PR TITLE
Add StatusCode enum

### DIFF
--- a/reticulum_openapi/__init__.py
+++ b/reticulum_openapi/__init__.py
@@ -1,0 +1,17 @@
+"""Reticulum OpenAPI package."""
+
+from .controller import Controller, APIException, handle_exceptions
+from .model import BaseModel, dataclass_from_json, dataclass_to_json
+from .service import LXMFService
+from .status import StatusCode
+
+__all__ = [
+    "Controller",
+    "APIException",
+    "handle_exceptions",
+    "BaseModel",
+    "dataclass_from_json",
+    "dataclass_to_json",
+    "LXMFService",
+    "StatusCode",
+]

--- a/reticulum_openapi/status.py
+++ b/reticulum_openapi/status.py
@@ -1,0 +1,23 @@
+from enum import IntEnum
+
+
+class StatusCode(IntEnum):
+    """Common HTTP-like status codes used by the framework."""
+
+    # Success 2xx
+    SUCCESS = 200
+    CREATED = 201
+    ACCEPTED = 202
+    NO_CONTENT = 204
+
+    # Client error 4xx
+    BAD_REQUEST = 400
+    UNAUTHORIZED = 401
+    FORBIDDEN = 403
+    NOT_FOUND = 404
+    CONFLICT = 409
+
+    # Server error 5xx
+    INTERNAL_SERVER_ERROR = 500
+    NOT_IMPLEMENTED = 501
+    SERVICE_UNAVAILABLE = 503

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,7 @@
+from reticulum_openapi.status import StatusCode
+
+
+def test_status_codes_values():
+    assert StatusCode.SUCCESS == 200
+    assert StatusCode.NOT_FOUND == 404
+    assert StatusCode.INTERNAL_SERVER_ERROR == 500


### PR DESCRIPTION
## Summary
- introduce `StatusCode` enumeration with common HTTP-like status codes
- re-export `StatusCode` from package init
- verify new class with tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532922df9c8325b8769c26bf3e6379