### PR TITLE
Add async context manager to LXMFService

### DIFF
--- a/examples/EmergencyManagement/Server/server_emergency.py
+++ b/examples/EmergencyManagement/Server/server_emergency.py
@@ -5,14 +5,9 @@ from examples.EmergencyManagement.Server.database import init_db
 
 async def main():
     await init_db()
-    svc = EmergencyService()
-    svc.announce()
-    service_task = asyncio.create_task(svc.start())
-    try:
+    async with EmergencyService() as svc:
+        svc.announce()
         await asyncio.sleep(30)  # Run for 30 seconds then stop
-    finally:
-        await svc.stop()
-        await service_task
 
 
 if __name__ == "__main__":

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -262,3 +262,16 @@ class LXMFService:
         else:
             # If start wasn't called yet, ensure router cleanup
             self.router.exit_handler()
+
+    async def __aenter__(self):
+        """Start the service when entering an async context."""
+        # Launch the start routine as a background task
+        self._context_task = asyncio.create_task(self.start())
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        """Stop the service when exiting an async context."""
+        await self.stop()
+        # Ensure the background task has completed
+        if hasattr(self, "_context_task"):
+            await self._context_task

--- a/tests/test_service_extra.py
+++ b/tests/test_service_extra.py
@@ -93,6 +93,20 @@ async def test_start_and_stop(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_context_manager(monkeypatch):
+    svc = service_module.LXMFService.__new__(service_module.LXMFService)
+    svc.router = SimpleNamespace(exit_handler=Mock())
+    svc._loop = asyncio.get_running_loop()
+    monkeypatch.setattr(service_module.RNS, "log", lambda *a, **k: None)
+
+    async with svc:
+        await asyncio.sleep(0.05)
+        assert svc._start_task is not None
+
+    assert svc._start_task is None
+
+
+@pytest.mark.asyncio
 async def test_init_and_add_route(monkeypatch):
     class FakeReticulum:
         storagepath = '/tmp'


### PR DESCRIPTION
## Summary
- implement `__aenter__` and `__aexit__` in `LXMFService`
- simplify emergency server example using `async with`
- test service context manager behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d637450cc8325a3277dfb5c2611ec