### PR TITLE
Add list serialization roundtrip test

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union
+from typing import List, Union
 from reticulum_openapi.model import dataclass_to_json, dataclass_from_json
 
 
@@ -9,11 +9,23 @@ class Item:
     value: int
 
 
+@dataclass
+class ItemList:
+    items: List[Item]
+
+
 def test_serialization_roundtrip():
     item = Item(name="foo", value=42)
     data = dataclass_to_json(item)
     obj = dataclass_from_json(Item, data)
     assert obj == item
+
+
+def test_list_of_items_roundtrip():
+    obj = ItemList(items=[Item(name="a", value=1), Item(name="b", value=2)])
+    data = dataclass_to_json(obj)
+    reconstructed = dataclass_from_json(ItemList, data)
+    assert reconstructed == obj
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- expand item serialization test coverage to include lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6387d6bc83259536a656d7600016