### PR TITLE
Add mustache templates

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,26 @@
+# Reticulum OpenAPI Mustache Templates
+
+These templates can be used with `openapi-generator-cli` to produce a working
+Reticulum LXMF service and client from an OpenAPI specification. The generated
+structure mirrors the `EmergencyManagement` example.
+
+## Usage
+
+```bash
+openapi-generator-cli generate \
+    -g python \
+    -i path/to/spec.yaml \
+    -t path/to/templates \
+    -o generated
+```
+
+The output will contain:
+
+- `models.py` – dataclasses for all schemas
+- `controllers.py` – controller classes with async handlers
+- `service.py` – `LXMFService` subclass registering routes
+- `server.py` – entrypoint starting the service
+- `client.py` – simple client invoking the first operation
+- `database.py` – example async database setup
+
+Adjust the generated code as needed for your specification.

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -1,0 +1,21 @@
+import asyncio
+from reticulum_openapi.client import LXMFClient
+from {{modelPackage}} import *
+
+async def main():
+    client = LXMFClient()
+    server_id = input("Server Identity Hash: ")
+{{#apiInfo}}
+{{#apis}}
+{{#operations}}
+{{#-first}}
+    payload = None
+    response = await client.send_command(server_id, "{{operationId}}", payload, await_response=True)
+    print("Response:", response)
+{{/-first}}
+{{/operations}}
+{{/apis}}
+{{/apiInfo}}
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/templates/controller.mustache
+++ b/templates/controller.mustache
@@ -1,0 +1,21 @@
+{{#apiInfo}}
+{{#apis}}
+from dataclasses import asdict
+from reticulum_openapi.controller import Controller, handle_exceptions
+from {{modelPackage}} import *
+from {{packageName}}.database import async_session
+
+
+class {{classname}}Controller(Controller):
+{{#operations}}
+    @handle_exceptions
+    async def {{operationId}}(self{{#hasParams}}, {{/hasParams}}{{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#bodyParam}}{{#hasParams}}, {{/hasParams}}{{paramName}}{{/bodyParam}}):
+        self.logger.info("{{operationId}} called")
+        async with async_session() as session:
+            # TODO: implement persistence or other logic
+            pass
+
+{{/operations}}
+
+{{/apis}}
+{{/apiInfo}}

--- a/templates/database.mustache
+++ b/templates/database.mustache
@@ -1,0 +1,10 @@
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+
+DATABASE_URL = "sqlite+aiosqlite:///{{appName}}.db"
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+async def init_db():
+    async with engine.begin() as conn:
+        pass  # place model metadata.create_all here if defined

--- a/templates/model.mustache
+++ b/templates/model.mustache
@@ -1,0 +1,23 @@
+{{#models}}
+{{#model}}
+{{#isEnum}}
+class {{classname}}(str):
+{{#allowableValues.values}}
+    {{.}} = "{{.}}"
+{{/allowableValues.values}}
+
+{{/isEnum}}
+{{^isEnum}}
+from dataclasses import dataclass
+from typing import Optional
+from reticulum_openapi.model import BaseModel
+
+@dataclass
+class {{classname}}(BaseModel):
+{{#vars}}
+    {{name}}: {{^required}}Optional[{{/required}}{{{datatype}}}{{^required}}] = None{{/required}}
+{{/vars}}
+
+{{/isEnum}}
+{{/model}}
+{{/models}}

--- a/templates/server.mustache
+++ b/templates/server.mustache
@@ -1,0 +1,12 @@
+import asyncio
+from {{packageName}}.service import {{appName}}Service
+from {{packageName}}.database import init_db
+
+async def main():
+    await init_db()
+    async with {{appName}}Service() as svc:
+        svc.announce()
+        await asyncio.sleep(30)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -1,0 +1,15 @@
+from reticulum_openapi.service import LXMFService
+from {{packageName}}.controllers import *
+from {{modelPackage}} import *
+
+class {{appName}}Service(LXMFService):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+{{#apiInfo}}
+{{#apis}}
+        ctrl_{{classname}} = {{classname}}Controller()
+{{#operations}}
+        self.add_route("{{operationId}}", ctrl_{{classname}}.{{operationId}}{{#bodyParam}}, {{bodyParam.dataType}}{{/bodyParam}})
+{{/operations}}
+{{/apis}}
+{{/apiInfo}}


### PR DESCRIPTION
## Summary
- add `templates/` directory with mustache templates for generating a Reticulum OpenAPI app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6435ce7483258cdffd3035a13305