### PR TITLE
Fix flake8 import style

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -117,7 +117,8 @@ async def test_send_command_includes_token(monkeypatch):
 
     await cli.send_command("aa", "CMD", Sample(text="hello"), await_response=False)
 
-    import json, zlib
+    import json
+    import zlib
     payload = json.loads(zlib.decompress(captured["content"]).decode())
     assert payload.get("auth_token") == "secret"
     assert payload.get("text") == "hello"


### PR DESCRIPTION
## Summary
- resolve E401 error in `tests/test_client.py`

## Testing
- `flake8 reticulum_openapi examples tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d7a8078c48325a4c30dcb1cdfc9d2