### PR TITLE
Inject auth token before command serialization

### DIFF
--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -1,16 +1,24 @@
 import asyncio
 import RNS
 import LXMF
+from dataclasses import asdict
+from dataclasses import is_dataclass
 from typing import Optional, Dict
-from .model import dataclass_to_json, dataclass_from_json
+from .model import dataclass_to_json
 
 
 class LXMFClient:
     """Simple client for sending commands and awaiting responses."""
 
-    def __init__(self, config_path: str = None, storage_path: str = None,
-                 identity: RNS.Identity = None, display_name: str = "OpenAPIClient",
-                 auth_token: str = None, timeout: float = 10.0):
+    def __init__(
+        self,
+        config_path: str = None,
+        storage_path: str = None,
+        identity: RNS.Identity = None,
+        display_name: str = "OpenAPIClient",
+        auth_token: str = None,
+        timeout: float = 10.0,
+    ):
         self.reticulum = RNS.Reticulum(config_path)
         storage_path = storage_path or (RNS.Reticulum.storagepath + "/lxmf_client")
         self.router = LXMF.LXMRouter(storagepath=storage_path)
@@ -32,8 +40,14 @@ class LXMFClient:
         if future is not None and not future.done():
             future.set_result(message.content)
 
-    async def send_command(self, dest_hex: str, command: str, payload_obj=None,
-                           await_response: bool = True, response_title: Optional[str] = None):
+    async def send_command(
+        self,
+        dest_hex: str,
+        command: str,
+        payload_obj=None,
+        await_response: bool = True,
+        response_title: Optional[str] = None,
+    ):
         dest_hash = bytes.fromhex(dest_hex)
         if not RNS.Transport.has_path(dest_hash):
             RNS.Transport.request_path(dest_hash)
@@ -41,24 +55,32 @@ class LXMFClient:
                 if RNS.Transport.has_path(dest_hash):
                     break
                 await asyncio.sleep(0.1)
-        dest_identity = RNS.Identity.recall(dest_hash) or RNS.Identity.recall(dest_hash, create=True)
+        dest_identity = RNS.Identity.recall(dest_hash) or RNS.Identity.recall(
+            dest_hash, create=True
+        )
         if payload_obj is None:
-            content_bytes = b''
+            content_bytes = b""
         elif isinstance(payload_obj, bytes):
             content_bytes = payload_obj
         else:
-            data = dataclass_to_json(payload_obj)
+            if is_dataclass(payload_obj):
+                data_dict = asdict(payload_obj)
+            else:
+                data_dict = payload_obj
             if self.auth_token:
-                import json
-                import zlib
-                obj = dataclass_from_json(type(payload_obj), data)
-                obj_dict = obj.__dict__
-                obj_dict['auth_token'] = self.auth_token
-                data = zlib.compress(json.dumps(obj_dict).encode('utf-8'))
-            content_bytes = data
+                data_dict["auth_token"] = self.auth_token
+            content_bytes = dataclass_to_json(data_dict)
         lxmsg = LXMF.LXMessage(
-            RNS.Destination(dest_identity, RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"),
-            self.source_identity, content_bytes, command
+            RNS.Destination(
+                dest_identity,
+                RNS.Destination.OUT,
+                RNS.Destination.SINGLE,
+                "lxmf",
+                "delivery",
+            ),
+            self.source_identity,
+            content_bytes,
+            command,
         )
         future = None
         if await_response:


### PR DESCRIPTION
## Summary
- ensure `send_command` injects `auth_token` into dataclass payloads before serialization
- test that authentication token is serialized once without redundant passes

## Testing
- `venv_linux/bin/python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895269c5c1483259a26ec6f1fd3ae92