### PR TITLE
Add asynchronous link client and service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Reticulum OpenAPI is an experimental framework for building lightweight APIs on 
 
 This repository contains the Python implementation of the framework as well as documentation, a full featured example and generator templates. The goal is to provide an easy way to build applications that communicate over Reticulum using structured messages.
 
+The project now also exposes primitives for maintaining persistent links via
+``LinkClient`` and ``LinkService`` which allow direct communication over an
+``RNS.Link`` in addition to LXMF messaging.
+
 See [docs/protocol_design.md](docs/protocol_design.md) for the protocol overview and [docs/Framework_design.md](docs/Framework_design.md) for architectural details.
 
 ## Quick start

--- a/reticulum_openapi/__init__.py
+++ b/reticulum_openapi/__init__.py
@@ -2,6 +2,8 @@
 
 from .controller import Controller, APIException, handle_exceptions
 from .model import BaseModel, dataclass_from_json, dataclass_to_json
+from .link_client import LinkClient
+from .link_service import LinkService
 from .service import LXMFService
 from .status import StatusCode
 
@@ -12,6 +14,8 @@ __all__ = [
     "BaseModel",
     "dataclass_from_json",
     "dataclass_to_json",
+    "LinkClient",
+    "LinkService",
     "LXMFService",
     "StatusCode",
 ]

--- a/reticulum_openapi/link_client.py
+++ b/reticulum_openapi/link_client.py
@@ -1,0 +1,126 @@
+import asyncio
+from dataclasses import asdict
+from dataclasses import is_dataclass
+from typing import Any
+from typing import Optional
+
+import RNS
+
+from .model import dataclass_to_json
+
+
+class LinkClient:
+    """Asynchronous client managing a persistent ``RNS.Link``."""
+
+    def __init__(
+        self, dest_hash: str, config_path: str = None, identity: RNS.Identity = None
+    ):
+        """Initialise and start the link.
+
+        Args:
+            dest_hash (str): Hex-encoded hash of the destination to link with.
+            config_path (str, optional): Reticulum configuration path. Defaults to ``None``.
+            identity (RNS.Identity, optional): Local identity. Defaults to a new identity.
+        """
+        self.reticulum = RNS.Reticulum(config_path)
+        self.identity = identity or RNS.Identity()
+        self._loop = asyncio.get_event_loop()
+        remote_hash = bytes.fromhex(dest_hash)
+        remote_id = RNS.Identity.recall(remote_hash) or RNS.Identity.recall(
+            remote_hash, create=True
+        )
+        destination = RNS.Destination(
+            remote_id,
+            RNS.Destination.OUT,
+            RNS.Destination.SINGLE,
+            "openapi",
+            "link",
+        )
+        self.link = RNS.Link(
+            destination,
+            established_callback=self._on_established,
+            closed_callback=self._on_closed,
+        )
+        self.link.set_packet_callback(self._handle_packet)
+        self.established = asyncio.Event()
+        self.closed = asyncio.Event()
+        self.packet_queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    def _on_established(self, _link: RNS.Link) -> None:
+        """Internal callback when link is established."""
+        self.established.set()
+
+    def _on_closed(self, _link: RNS.Link) -> None:
+        """Internal callback when link is closed."""
+        self.closed.set()
+
+    def _handle_packet(self, data: bytes, _packet: Optional[Any] = None) -> None:
+        """Queue incoming packets for later processing."""
+        try:
+            self.packet_queue.put_nowait(data)
+        except asyncio.QueueFull:
+            pass
+
+    async def send(self, data: Any) -> None:
+        """Send raw bytes or a dataclass/dict to the peer.
+
+        Args:
+            data (Any): Payload to transmit. If not ``bytes`` it will be
+                serialised using :func:`dataclass_to_json`.
+        """
+        if isinstance(data, bytes):
+            payload = data
+        else:
+            if is_dataclass(data):
+                data = asdict(data)
+            payload = dataclass_to_json(data)
+        self.link.send(payload)
+
+    async def request(
+        self, path: str, data: Any = None, timeout: Optional[float] = None
+    ) -> bytes:
+        """Send a request over the link and await a response.
+
+        Args:
+            path (str): Remote path string.
+            data (Any, optional): Optional payload. Uses
+                :func:`dataclass_to_json` if not ``bytes``. Defaults to ``None``.
+            timeout (float, optional): Request timeout in seconds. Defaults to
+                ``None`` letting Reticulum choose.
+
+        Returns:
+            bytes: Response payload.
+        """
+        payload: Optional[bytes]
+        if data is None:
+            payload = None
+        elif isinstance(data, bytes):
+            payload = data
+        else:
+            if is_dataclass(data):
+                data = asdict(data)
+            payload = dataclass_to_json(data)
+
+        fut: asyncio.Future[bytes] = self._loop.create_future()
+
+        def resp_cb(receipt: Any) -> None:
+            if not fut.done():
+                fut.set_result(receipt.response)
+
+        def fail_cb(_receipt: Any) -> None:
+            if not fut.done():
+                fut.set_exception(RuntimeError("Request failed"))
+
+        self.link.request(
+            path,
+            data=payload,
+            response_callback=resp_cb,
+            failed_callback=fail_cb,
+            timeout=timeout,
+        )
+        return await fut
+
+    def identify(self, identity: RNS.Identity) -> None:
+        """Identify to the remote peer using the provided ``RNS.Identity``."""
+        if self.link is not None:
+            self.link.identify(identity)

--- a/reticulum_openapi/link_service.py
+++ b/reticulum_openapi/link_service.py
@@ -1,0 +1,88 @@
+import asyncio
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from typing import Dict
+from typing import Optional
+
+import RNS
+
+
+class LinkService:
+    """Service accepting incoming ``RNS.Link`` connections."""
+
+    def __init__(
+        self,
+        config_path: str = None,
+        identity: RNS.Identity = None,
+        link_handler: Optional[Callable[[RNS.Link], Awaitable[Any]]] = None,
+        keepalive_interval: float = RNS.Link.KEEPALIVE,
+    ):
+        """Create the service and register the link callback.
+
+        Args:
+            config_path (str, optional): Reticulum configuration path.
+            identity (RNS.Identity, optional): Service identity. A new
+                identity is created if omitted.
+            link_handler (Callable, optional): Async callable executed for each
+                established link.
+            keepalive_interval (float, optional): Seconds between keep-alive
+                transmissions.
+        """
+        self.reticulum = RNS.Reticulum(config_path)
+        self.identity = identity or RNS.Identity()
+        self._loop = asyncio.get_event_loop()
+        self.destination = RNS.Destination(
+            self.identity,
+            RNS.Destination.IN,
+            RNS.Destination.SINGLE,
+            "openapi",
+            "link",
+        )
+        self.destination.accepts_links = True
+        self.destination.set_link_established_callback(self._link_established)
+        self._link_handler = link_handler
+        self.keepalive_interval = keepalive_interval
+        self.active_links: Dict[bytes, RNS.Link] = {}
+        self._keepalive_tasks: Dict[bytes, asyncio.Task] = {}
+
+    def _link_established(self, link: RNS.Link) -> None:
+        """Handle a newly established link."""
+        self.active_links[link.link_id] = link
+        link.set_link_closed_callback(self._link_closed)
+        if self._link_handler is not None:
+            self._loop.call_soon_threadsafe(
+                lambda: asyncio.create_task(self._link_handler(link))
+            )
+        task = asyncio.create_task(self._keepalive(link))
+        self._keepalive_tasks[link.link_id] = task
+
+    def _link_closed(self, link: RNS.Link) -> None:
+        """Remove closed links and cancel keep-alive."""
+        self.active_links.pop(link.link_id, None)
+        task = self._keepalive_tasks.pop(link.link_id, None)
+        if task is not None:
+            task.cancel()
+
+    async def _keepalive(self, link: RNS.Link) -> None:
+        """Periodically send keep-alive packets."""
+        try:
+            while link.link_id in self.active_links:
+                await asyncio.sleep(self.keepalive_interval)
+                link.send_keepalive()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            pass
+
+    async def stop(self) -> None:
+        """Close all active links and cancel keep-alive tasks."""
+        for link_id, link in list(self.active_links.items()):
+            try:
+                link.close()
+            except Exception:
+                pass
+            self.active_links.pop(link_id, None)
+        for task in self._keepalive_tasks.values():
+            task.cancel()
+        self._keepalive_tasks.clear()

--- a/tests/test_link_client.py
+++ b/tests/test_link_client.py
@@ -1,0 +1,106 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from reticulum_openapi import link_client as lc_module
+
+
+class FakeLink:
+    def __init__(self, _dest, established_callback=None, closed_callback=None):
+        self.sent = []
+        self.requests = []
+        self.ident_called_with = None
+        self.established_callback = established_callback
+        self.closed_callback = closed_callback
+        self.packet_callback = None
+        if established_callback:
+            established_callback(self)
+
+    def set_packet_callback(self, cb):
+        self.packet_callback = cb
+
+    def send(self, data):
+        self.sent.append(data)
+
+    def request(
+        self,
+        path,
+        data=None,
+        response_callback=None,
+        failed_callback=None,
+        timeout=None,
+    ):
+        self.requests.append((path, data))
+        self._response_callback = response_callback
+        self._failed_callback = failed_callback
+        return SimpleNamespace()
+
+    def identify(self, identity):
+        self.ident_called_with = identity
+
+    # helper used in tests
+    def respond(self, payload: bytes):
+        receipt = SimpleNamespace(response=payload)
+        if self._response_callback:
+            self._response_callback(receipt)
+
+
+class FakeDestination:
+    OUT = object()
+    SINGLE = object()
+
+    def __init__(self, *a, **k):
+        pass
+
+
+class FakeIdentity:
+    def __init__(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_send_serializes_dict(monkeypatch):
+    monkeypatch.setattr(lc_module.RNS, "Reticulum", lambda *_: object())
+    monkeypatch.setattr(lc_module.RNS, "Identity", FakeIdentity)
+    monkeypatch.setattr(lc_module.RNS, "Destination", FakeDestination)
+    monkeypatch.setattr(lc_module.RNS, "Link", FakeLink)
+
+    captured = {}
+    monkeypatch.setattr(
+        lc_module,
+        "dataclass_to_json",
+        lambda d: captured.setdefault("payload", d) or b"data",
+    )
+
+    cli = lc_module.LinkClient("aa")
+    await cli.send({"k": "v"})
+    assert captured["payload"] == {"k": "v"}
+    assert cli.link.sent[0] == b"data"
+
+
+@pytest.mark.asyncio
+async def test_request_returns_response(monkeypatch):
+    monkeypatch.setattr(lc_module.RNS, "Reticulum", lambda *_: object())
+    monkeypatch.setattr(lc_module.RNS, "Identity", FakeIdentity)
+    monkeypatch.setattr(lc_module.RNS, "Destination", FakeDestination)
+    monkeypatch.setattr(lc_module.RNS, "Link", FakeLink)
+
+    cli = lc_module.LinkClient("aa")
+    task = asyncio.create_task(cli.request("/path", {"a": 1}))
+    cli.link.respond(b"ok")
+    resp = await task
+    assert resp == b"ok"
+
+
+@pytest.mark.asyncio
+async def test_identify_calls_link(monkeypatch):
+    monkeypatch.setattr(lc_module.RNS, "Reticulum", lambda *_: object())
+    monkeypatch.setattr(lc_module.RNS, "Identity", FakeIdentity)
+    monkeypatch.setattr(lc_module.RNS, "Destination", FakeDestination)
+    monkeypatch.setattr(lc_module.RNS, "Link", FakeLink)
+
+    cli = lc_module.LinkClient("aa")
+    ident = FakeIdentity()
+    cli.identify(ident)
+    assert cli.link.ident_called_with is ident

--- a/tests/test_link_service.py
+++ b/tests/test_link_service.py
@@ -1,0 +1,78 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from reticulum_openapi import link_service as ls_module
+
+
+class FakeLink:
+    def __init__(self, link_id=b"1"):
+        self.link_id = link_id
+        self.closed_callback = None
+        self.keepalives = 0
+        self.closed = False
+
+    def set_link_closed_callback(self, cb):
+        self.closed_callback = cb
+
+    def send_keepalive(self):
+        self.keepalives += 1
+
+    def close(self):
+        self.closed = True
+        if self.closed_callback:
+            self.closed_callback(self)
+
+
+class FakeDestination:
+    IN = object()
+    SINGLE = object()
+
+    def __init__(self, *a, **k):
+        self.accepts_links = False
+        self.callbacks = SimpleNamespace()
+
+    def set_link_established_callback(self, cb):
+        self.callbacks.link_established = cb
+
+
+class FakeIdentity:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_service_accepts_links_and_keepalive(monkeypatch):
+    monkeypatch.setattr(ls_module.RNS, "Reticulum", lambda *_: object())
+    monkeypatch.setattr(ls_module.RNS, "Identity", FakeIdentity)
+    monkeypatch.setattr(ls_module.RNS, "Destination", FakeDestination)
+
+    handler_called = asyncio.Event()
+
+    async def handler(_link):
+        handler_called.set()
+
+    service = ls_module.LinkService(link_handler=handler, keepalive_interval=0.01)
+    link = FakeLink()
+    service._link_established(link)
+    await asyncio.sleep(0.03)
+    assert handler_called.is_set()
+    assert link.keepalives > 0
+    assert link.link_id in service.active_links
+
+    link.close()
+    assert link.link_id not in service.active_links
+
+
+@pytest.mark.asyncio
+async def test_service_stop_closes_links(monkeypatch):
+    monkeypatch.setattr(ls_module.RNS, "Reticulum", lambda *_: object())
+    monkeypatch.setattr(ls_module.RNS, "Identity", FakeIdentity)
+    monkeypatch.setattr(ls_module.RNS, "Destination", FakeDestination)
+
+    service = ls_module.LinkService(keepalive_interval=0.1)
+    link = FakeLink()
+    service._link_established(link)
+    await service.stop()
+    assert link.closed
+    assert service.active_links == {}


### PR DESCRIPTION
## Summary
- implement `LinkClient` for managing persistent RNS links, sending packets and handling requests
- add `LinkService` to accept inbound links, spawn handlers and keep connections alive
- document link primitives in README and export new classes

## Testing
- `flake8 --exclude=venv_linux` *(fails: E302 expected 2 blank lines, found 1, etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'runtime')*


------
https://chatgpt.com/codex/tasks/task_e_6899e79f12ac8325a1d7ac1fbdf73f61