### PR TITLE
Add link resource transfer helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv_linux/
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This repository contains the Python implementation of the framework as well as d
 
 See [docs/protocol_design.md](docs/protocol_design.md) for the protocol overview and [docs/Framework_design.md](docs/Framework_design.md) for architectural details.
 
+## Resource transfers
+
+The package also includes helpers for sending and receiving larger files over Reticulum links. Use
+`LinkClient.send_resource()` to upload a file with progress reporting and
+`LinkService.resource_received_callback()` to store incoming resources in a chosen directory.
+
 ## Quick start
 
 Install dependencies (requires Python 3.8+):

--- a/reticulum_openapi/__init__.py
+++ b/reticulum_openapi/__init__.py
@@ -4,6 +4,8 @@ from .controller import Controller, APIException, handle_exceptions
 from .model import BaseModel, dataclass_from_json, dataclass_to_json
 from .service import LXMFService
 from .status import StatusCode
+from .link_client import LinkClient
+from .link_service import LinkService
 
 __all__ = [
     "Controller",
@@ -14,4 +16,6 @@ __all__ = [
     "dataclass_to_json",
     "LXMFService",
     "StatusCode",
+    "LinkClient",
+    "LinkService",
 ]

--- a/reticulum_openapi/link_client.py
+++ b/reticulum_openapi/link_client.py
@@ -1,0 +1,62 @@
+"""Utilities for sending files over Reticulum links."""
+
+import os
+from typing import Callable
+from typing import Optional
+
+import RNS
+
+
+class LinkClient:
+    """Client helper for sending resources over an established link."""
+
+    def __init__(
+        self,
+        link: RNS.Link,
+        on_upload_complete: Optional[Callable[[RNS.Resource], None]] = None,
+    ) -> None:
+        """Initialize the client.
+
+        Args:
+            link (RNS.Link): Active link used for resource transmission.
+            on_upload_complete (Callable[[RNS.Resource], None], optional):
+                Called whenever a resource finishes sending.
+        """
+        self.link = link
+        self.on_upload_complete = on_upload_complete
+
+    def send_resource(
+        self,
+        path: str,
+        progress_callback: Optional[Callable[[RNS.Resource], None]] = None,
+        completion_callback: Optional[Callable[[RNS.Resource], None]] = None,
+    ) -> RNS.Resource:
+        """Send a file as a resource over the link.
+
+        Args:
+            path (str): Path to the file that should be transmitted.
+            progress_callback (Callable[[RNS.Resource], None], optional):
+                Invoked with transfer progress updates.
+            completion_callback (Callable[[RNS.Resource], None], optional):
+                Invoked when the transfer is completed.
+
+        Returns:
+            RNS.Resource: The created resource instance.
+        """
+
+        metadata = {"filename": os.path.basename(path)}
+
+        def _wrapped_callback(resource: RNS.Resource) -> None:
+            if completion_callback:
+                completion_callback(resource)
+            if self.on_upload_complete:
+                self.on_upload_complete(resource)
+
+        resource = RNS.Resource(
+            path,
+            self.link,
+            metadata=metadata,
+            callback=_wrapped_callback,
+            progress_callback=progress_callback,
+        )
+        return resource

--- a/reticulum_openapi/link_service.py
+++ b/reticulum_openapi/link_service.py
@@ -1,0 +1,57 @@
+"""Helpers for handling incoming resources on Reticulum links."""
+
+import os
+import shutil
+from typing import Callable
+from typing import Optional
+
+import RNS
+
+
+class LinkService:
+    """Service utilities for receiving resources on a link."""
+
+    def __init__(
+        self,
+        storage_dir: str,
+        on_download_complete: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        """Initialize the service.
+
+        Args:
+            storage_dir (str): Directory where received files are stored.
+            on_download_complete (Callable[[str], None], optional):
+                Called with the file path when a resource is stored.
+        """
+        self.storage_dir = storage_dir
+        self.on_download_complete = on_download_complete
+        os.makedirs(self.storage_dir, exist_ok=True)
+
+    def resource_received_callback(self, resource: RNS.Resource) -> None:
+        """Store an incoming resource on disk.
+
+        Args:
+            resource (RNS.Resource): The received resource.
+        """
+        filename = None
+        if getattr(resource, "metadata", None) and isinstance(resource.metadata, dict):
+            filename = resource.metadata.get("filename")
+        if not filename:
+            filename = getattr(resource, "hash", b"").hex()
+        dest_path = os.path.join(self.storage_dir, filename)
+        try:
+            if getattr(resource, "storagepath", None) and os.path.isfile(
+                resource.storagepath
+            ):
+                shutil.move(resource.storagepath, dest_path)
+            elif getattr(resource, "data", None):
+                with open(dest_path, "wb") as file:
+                    data = resource.data
+                    if hasattr(data, "read"):
+                        file.write(data.read())
+                    elif isinstance(data, bytes):
+                        file.write(data)
+            if self.on_download_complete:
+                self.on_download_complete(dest_path)
+        except Exception as exc:
+            RNS.log(f"Failed to store resource: {exc}")

--- a/tests/test_link_resources.py
+++ b/tests/test_link_resources.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+
+import pytest
+
+from reticulum_openapi import link_client
+from reticulum_openapi import link_service
+
+
+class DummyResource:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def test_send_resource_callbacks(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("payload")
+
+    calls = {"progress": False, "completion": False, "hook": False}
+    fake_link = object()
+
+    class FakeResource:
+        def __init__(
+            self, data, link, metadata=None, callback=None, progress_callback=None, **_
+        ):
+            assert data == str(file_path)
+            assert link is fake_link
+            assert metadata["filename"] == "data.txt"
+            if progress_callback:
+                progress_callback(self)
+            if callback:
+                callback(self)
+
+    monkeypatch.setattr(link_client.RNS, "Resource", FakeResource)
+
+    def progress(res):
+        calls["progress"] = True
+
+    def completion(res):
+        calls["completion"] = True
+
+    def hook(res):
+        calls["hook"] = True
+
+    cli = link_client.LinkClient(fake_link, on_upload_complete=hook)
+    cli.send_resource(
+        str(file_path), progress_callback=progress, completion_callback=completion
+    )
+
+    assert calls["progress"]
+    assert calls["completion"]
+    assert calls["hook"]
+
+
+def test_send_resource_raises(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("payload")
+
+    def raise_resource(*a, **k):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(link_client.RNS, "Resource", raise_resource)
+    cli = link_client.LinkClient(object())
+    with pytest.raises(ValueError):
+        cli.send_resource(str(file_path))
+
+
+def test_resource_received_callback(tmp_path):
+    storage = tmp_path / "store"
+    service = link_service.LinkService(str(storage))
+
+    src_path = tmp_path / "incoming"
+    src_path.write_bytes(b"content")
+    res = SimpleNamespace(
+        metadata={"filename": "file.txt"}, storagepath=str(src_path), hash=b"\x01\x02"
+    )
+
+    service.resource_received_callback(res)
+
+    saved = storage / "file.txt"
+    assert saved.read_bytes() == b"content"
+
+
+def test_resource_received_callback_no_metadata(tmp_path):
+    storage = tmp_path / "store"
+    called = {}
+
+    def hook(path):
+        called["path"] = path
+
+    service = link_service.LinkService(str(storage), on_download_complete=hook)
+
+    src_path = tmp_path / "incoming"
+    src_path.write_bytes(b"data")
+    res = SimpleNamespace(metadata=None, storagepath=str(src_path), hash=b"\x0a\x0b")
+
+    service.resource_received_callback(res)
+
+    expected = storage / res.hash.hex()
+    assert expected.read_bytes() == b"data"
+    assert called["path"] == str(expected)


### PR DESCRIPTION
## Summary
- add LinkClient for sending files over RNS links with progress and completion callbacks
- add LinkService for saving received resources and triggering hooks
- document resource transfer helpers

## Testing
- `venv_linux/bin/flake8 reticulum_openapi/link_client.py reticulum_openapi/link_service.py reticulum_openapi/__init__.py tests/test_link_resources.py`
- `venv_linux/bin/pytest` *(fails: ModuleNotFoundError: No module named 'runtime')*


------
https://chatgpt.com/codex/tasks/task_e_6899e7cb63f08325bf530a222d66f431