### PR TITLE
Fix flake8 violations and clean up imports

### DIFF
--- a/examples/EmergencyManagement/Server/models_emergency.py
+++ b/examples/EmergencyManagement/Server/models_emergency.py
@@ -13,7 +13,6 @@ Base = declarative_base()
 # to avoid coupling the DB to the internal domain representation?
 
 
-
 class EmergencyActionMessageORM(Base):
     __tablename__ = "emergency_action_messages"
     callsign = Column(String, primary_key=True)

--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -1,8 +1,6 @@
 import asyncio
 import RNS
 import LXMF
-import json
-import zlib
 from dataclasses import asdict
 from dataclasses import is_dataclass
 from typing import Optional

--- a/reticulum_openapi/controller.py
+++ b/reticulum_openapi/controller.py
@@ -4,10 +4,7 @@ from typing import Callable
 from typing import Coroutine
 from typing import TypeVar
 
-
-
 # pretty sure every import of this class will trigger a new addHandler event which will result
-
 # in as many duplicate handlers for the controller logger as there are imports.
 # Setup module logger
 logger = logging.getLogger("reticulum_openapi.controller")
@@ -29,7 +26,6 @@ class APIException(Exception):
 
 # not clear on the purpose of a typevar here?
 F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
-
 
 
 # requires functools.wraps decorator
@@ -69,7 +65,6 @@ class Controller:
     async def run_business_logic(
         self, logic: Coroutine[Any, Any, Any], *args, **kwargs
     ) -> Any:
-
         """
         Execute a business logic coroutine with standardized logging and error handling.
         Returns the result or a structured error dict.
@@ -89,4 +84,3 @@ class Controller:
                 f"Unhandled exception in business logic {logic.__name__}: {e}"
             )
             return {"error": "InternalServerError", "code": 500}
-# no EOF newline?

--- a/reticulum_openapi/model.py
+++ b/reticulum_openapi/model.py
@@ -26,7 +26,6 @@ __all__ = [
 T = TypeVar("T")
 
 
-
 # not a fan of the design of this file and compromises it makes
 def dataclass_to_json(data_obj: T) -> bytes:
     """

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -100,6 +100,7 @@ class LXMFService:
         """Handler for the built-in GetSchema command."""
 
         return self.get_api_specification()
+
     def _lxmf_delivery_callback(self, message: LXMF.LXMessage):
         """
         Internal callback invoked by LXMRouter on message delivery.
@@ -283,7 +284,6 @@ class LXMFService:
         except Exception as e:
 
             RNS.log(f"Announcement failed: {e}")
-
 
     async def start(self):
         """Run the service until cancelled."""

--- a/reticulum_openapi/status.py
+++ b/reticulum_openapi/status.py
@@ -8,7 +8,6 @@ from enum import IntEnum
 # generation source.
 
 
-
 class StatusCode(IntEnum):
     """Common HTTP-like status codes used by the framework."""
 

--- a/tests/test_codec_msgpack.py
+++ b/tests/test_codec_msgpack.py
@@ -1,72 +1,78 @@
-
-# tests/test_codec_msgpack.py
-import os
-import sys
 import importlib
-from pathlib import Path
-
-BASE = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(BASE))
-
 import pytest
 
-codec = importlib.import_module("runtime.codec_msgpack")
+from reticulum_openapi import codec_msgpack as codec
+
 
 def test_basic_integers():
-    # 127 => 0x7f
+    """Verify canonical encoding of basic integers."""
     b = codec.to_canonical_bytes(127)
-    assert b == b'\x7f'
-    # 128 => uint8 0xcc 0x80
+    assert b == b"\x7f"
     b = codec.to_canonical_bytes(128)
-    assert b == b'\xcc\x80'
-    # -1 => 0xff
+    assert b == b"\xcc\x80"
     b = codec.to_canonical_bytes(-1)
-    assert b == b'\xff'
+    assert b == b"\xff"
+
 
 def test_basic_strings_and_bins():
+    """Ensure strings and binary data are encoded correctly."""
     b = codec.to_canonical_bytes("a")
-    assert b == b'\xa1a'
-    data = codec.to_canonical_bytes(b'\x01\x02')
-    assert data == b'\xc4\x02\x01\x02'
+    assert b == b"\xa1a"
+    data = codec.to_canonical_bytes(b"\x01\x02")
+    assert data == b"\xc4\x02\x01\x02"
+
 
 def test_arrays_and_maps_ordering():
+    """Arrays and maps should preserve ordering for canonical form."""
     b = codec.to_canonical_bytes(["x", 1, True])
-    assert b.startswith(b'\x93')  # fixarray of size 3
-    # Map ordering: keys sorted by UTF-8 bytes
+    assert b.startswith(b"\x93")
     obj = {"b": 1, "a": 2}
     enc = codec.to_canonical_bytes(obj)
-    expected = b'\x82' + b'\xa1a' + b'\x02' + b'\xa1b' + b'\x01'
+    expected = b"\x82" + b"\xa1a" + b"\x02" + b"\xa1b" + b"\x01"
     assert enc == expected
 
+
 def test_disallow_float():
-    import math
+    """Floats should not be allowed for canonical bytes."""
     with pytest.raises(codec.CodecError):
         codec.to_canonical_bytes(1.23)
     with pytest.raises(codec.CodecError):
-        codec.to_canonical_bytes(float('nan'))
+        codec.to_canonical_bytes(float("nan"))
 
-@pytest.mark.skipif(importlib.util.find_spec("msgpack") is None, reason="msgpack not installed")
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("msgpack") is None, reason="msgpack not installed"
+)
 def test_roundtrip_with_msgpack():
+    """Round-trip encode/decode using msgpack when available."""
     obj = {"a": 1, "b": ["x", 2], "c": None}
     b = codec.to_canonical_bytes(obj)
     back = codec.from_bytes(b)
     assert back == obj
 
-@pytest.mark.skipif(importlib.util.find_spec("blake3") is None, reason="blake3 not installed")
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("blake3") is None, reason="blake3 not installed"
+)
 def test_digest_stability_blake3():
+    """Digest results should be stable when using blake3."""
     obj = {"a": 1, "b": "x"}
     d1 = codec.digest(obj)
     d2 = codec.digest(obj)
     assert d1 == d2 and len(d1) == 32
 
-@pytest.mark.skipif(importlib.util.find_spec("nacl") is None, reason="PyNaCl not installed")
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("nacl") is None, reason="PyNaCl not installed"
+)
 def test_sign_verify_ed25519():
+    """Ed25519 signatures should verify correctly."""
     from nacl.signing import SigningKey
+
     sk = SigningKey.generate()
     pk = sk.verify_key
     msg = codec.to_canonical_bytes({"rid": "r", "ts": 1, "op": "o"})
     sig = codec.sign(msg, sk)
     assert codec.verify(msg, pk, sig) is True
-    # tamper
-    tampered = msg + b'\x00'
+    tampered = msg + b"\x00"
     assert codec.verify(tampered, pk, sig) is False

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3,8 +3,6 @@ from reticulum_openapi.status import StatusCode
 # this is a junk test
 
 
-
-
 def test_status_codes_values():
     assert StatusCode.SUCCESS == 200
     assert StatusCode.NOT_FOUND == 404


### PR DESCRIPTION
## Summary
- remove unused imports and normalize blank lines across modules
- tidy test modules and add basic docstrings for message pack codec tests

## Testing
- `flake8 reticulum_openapi examples tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899ef7fbe588325be0f16e26ab3996e