### PR TITLE
Add LinkService demo example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv_linux/
 
 # Spyder project settings
 .spyderproject

--- a/examples/LinkDemo/client.py
+++ b/examples/LinkDemo/client.py
@@ -1,0 +1,56 @@
+"""Client for the LinkService demo."""
+
+import os
+import sys
+import time
+from typing import Optional
+
+import RNS
+
+
+def on_link(link: RNS.Link, file_path: Optional[str]) -> None:
+    """Send a ping and optionally upload a file once the link is ready.
+
+    Args:
+        link: Established link to the server.
+        file_path: Path to a file to upload. If ``None``, no file is sent.
+    """
+    print("Link established")
+    link.set_packet_callback(lambda data, packet: print("Echo:", data))
+    RNS.Packet(link, b"hello").send()
+    if file_path and os.path.exists(file_path):
+        with open(file_path, "rb") as handle:
+            RNS.Resource(handle, link)
+    else:
+        print("No file uploaded")
+
+
+def main(dest_hex: str, file_path: Optional[str] = None) -> None:
+    """Connect to the server and demonstrate link usage.
+
+    Args:
+        dest_hex: Hexadecimal hash of the server destination.
+        file_path: Optional path to a file to upload.
+    """
+    RNS.Reticulum()
+    dest_hash = bytes.fromhex(dest_hex)
+    dest = RNS.Destination(
+        dest_hash,
+        RNS.Destination.OUT,
+        RNS.Destination.SINGLE,
+        "linkdemo",
+        "service",
+    )
+    RNS.Link(dest, established_callback=lambda link: on_link(link, file_path))
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python client.py <server_hash> [file]")
+    else:
+        main(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else None)

--- a/examples/LinkDemo/sample.txt
+++ b/examples/LinkDemo/sample.txt
@@ -1,0 +1,1 @@
+Sample file for upload over RNS LinkService.

--- a/examples/LinkDemo/server.py
+++ b/examples/LinkDemo/server.py
@@ -1,0 +1,74 @@
+"""Echo and file upload demo using RNS LinkService."""
+
+import time
+from typing import Optional
+
+import RNS
+
+
+class LinkService:
+    """Service that echoes packets and stores uploaded files."""
+
+    def __init__(self, config_path: Optional[str] = None) -> None:
+        """Initialize Reticulum and announce the service.
+
+        Args:
+            config_path: Optional path to the Reticulum configuration directory.
+        """
+        self.reticulum = RNS.Reticulum(config_path)
+        self.identity = RNS.Identity()
+        self.destination = RNS.Destination(
+            self.identity,
+            RNS.Destination.IN,
+            RNS.Destination.SINGLE,
+            "linkdemo",
+            "service",
+        )
+        self.destination.set_link_established_callback(self.link_established)
+        self.destination.accepts_links(True)
+        print("Service hash:", RNS.prettyhexrep(self.destination.hash))
+        self.destination.announce()
+
+    def link_established(self, link: RNS.Link) -> None:
+        """Configure callbacks for a newly established link.
+
+        Args:
+            link: The established link instance.
+        """
+        print("Link established from", RNS.prettyhexrep(link.remote_identity.hash))
+        link.set_packet_callback(self.packet_received)
+        link.set_resource_strategy(RNS.Link.ACCEPT_ALL)
+        link.set_resource_concluded_callback(self.resource_concluded)
+
+    def packet_received(self, data: bytes, packet: RNS.Packet) -> None:
+        """Echo any received data back to the sender.
+
+        Args:
+            data: Raw payload received over the link.
+            packet: The packet object containing metadata.
+        """
+        print("Received packet:", data)
+        RNS.Packet(packet.link, data).send()
+
+    def resource_concluded(self, resource: RNS.Resource) -> None:
+        """Persist a completed resource to disk.
+
+        Args:
+            resource: The finished inbound resource.
+        """
+        filename = f"upload_{RNS.hexrep(resource.hash)}"
+        with open(filename, "wb") as handle:
+            handle.write(resource.data.read())
+        print("Stored file", filename)
+
+    def run(self) -> None:
+        """Run the service indefinitely."""
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            pass
+
+
+if __name__ == "__main__":
+    LinkService().run()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# Examples
+
+This directory contains sample applications built with Reticulum OpenAPI.
+
+- `EmergencyManagement` – full-featured emergency management demo.
+- `filmology` – OpenAPI specification for a movie catalog service.
+- `LinkDemo` – minimal demonstration of establishing an RNS link, exchanging packets, and uploading a file.
+
+## LinkDemo
+
+1. Start the server:
+   ```bash
+   python examples/LinkDemo/server.py
+   ```
+   The service prints its identity hash.
+2. Run the client in another terminal, replacing `<hash>` with the printed value:
+   ```bash
+   python examples/LinkDemo/client.py <hash> examples/LinkDemo/sample.txt
+   ```
+   The client establishes a link, receives an echo response, and uploads a file which the server stores in its working directory.

--- a/tests/test_example_linkdemo_imports.py
+++ b/tests/test_example_linkdemo_imports.py
@@ -1,0 +1,15 @@
+"""Basic import tests for the LinkDemo example."""
+
+import importlib
+
+
+def test_server_module_imports() -> None:
+    """Server module should be importable and expose LinkService."""
+    module = importlib.import_module("examples.LinkDemo.server")
+    assert hasattr(module, "LinkService")
+
+
+def test_client_module_imports() -> None:
+    """Client module should be importable and define main."""
+    module = importlib.import_module("examples.LinkDemo.client")
+    assert hasattr(module, "main")


### PR DESCRIPTION
## Summary
- add LinkDemo server that echoes messages and stores uploaded files
- provide client script to establish a link, exchange data and upload a file
- document new LinkDemo and add basic import tests

## Testing
- `flake8 examples/LinkDemo/server.py examples/LinkDemo/client.py tests/test_example_linkdemo_imports.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'runtime')*

------
https://chatgpt.com/codex/tasks/task_e_6899e7d23a6083259080f21bcb501310