### PR TITLE
Document link mode and usage examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv_linux/
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ This repository contains the Python implementation of the framework as well as d
 
 See [docs/protocol_design.md](docs/protocol_design.md) for the protocol overview and [docs/Framework_design.md](docs/Framework_design.md) for architectural details.
 
+## Communication Modes
+
+The framework can operate in two different modes depending on the type of
+interaction required:
+
+- **LXMF messages** – Asynchronous store‑and‑forward messaging. Each request
+  and response fits in a single LXMF envelope, making it ideal for low bandwidth
+  or intermittently connected links.
+- **Link sessions** – A real‑time `RNS.Link` between peers. Links provide lower
+  latency and support streaming data or large transfers at the cost of keeping a
+  connection alive.
+
+Use LXMF for command/response APIs and situations where delivery may be delayed.
+Choose Link mode when you need interactive exchanges or to move large resources
+efficiently.
+
 ## Quick start
 
 Install dependencies (requires Python 3.8+):

--- a/docs/Framework_design.md
+++ b/docs/Framework_design.md
@@ -79,6 +79,23 @@ In effect, the Service layer operates like an **async message router and dispatc
 * **Registration of handlers:** Provides an API to register controllers or individual command handlers. For example, during startup the application might call `service.register_controller(NodeController())`, and the service will introspect or use a predefined mapping to associate `"add_node"` command with `NodeController.add_node` coroutine.
 * **Decoupling:** The service is decoupled from specific controllers; it references them via an interface (e.g., an abstract base class or simply through the mapping). This decoupling means new controllers can be added or a different transport service can reuse the controllers.
 
+## Link Establishment, Keep-Alive, and Resource Transfer Flows
+
+Some interactions require a persistent `RNS.Link` instead of single LXMF messages.
+Establishing a link performs a cryptographic handshake and derives ephemeral
+session keys so both parties can exchange packets in real time.
+
+1. **Link establishment:** A client creates a destination for the server and
+   instantiates `RNS.Link(dest)`. Once the `established_callback` fires, the link
+   is ready for packet-based communication.
+2. **Keep-alive:** Links expire if idle. Either side should periodically call
+   `link.send_keepalive()` or send any packet to keep the session open.
+3. **Resource transfer:** Large binary payloads use `RNS.Resource(data, link)`
+   which segments, retransmits, and proves delivery over the established link.
+
+Using link mode enables low-latency exchanges and efficient file transfers while
+maintaining the security guarantees of Reticulum.
+
 ## Message Routing Mechanism
 
 Message routing in the Reticulum OpenAPI framework determines how incoming LXMF messages are directed to the correct controller endpoint and how responses find their way back to the sender. It leverages the LXMF message structure – particularly the **Fields dictionary for routing metadata and the Content for payload** – to emulate a request/response API on top of an asynchronous, store-and-forward network.

--- a/docs/api_usage_patterns.md
+++ b/docs/api_usage_patterns.md
@@ -1,0 +1,43 @@
+# API Usage Patterns
+
+Examples of how to interact with the framework at different levels.
+
+## Command Requests
+
+Use the high level `LXMFClient` to send structured requests and await a
+response:
+
+```python
+from reticulum_openapi.client import LXMFClient
+
+client = LXMFClient()
+payload = {"echo": "hello"}
+reply = await client.send_command(server_hash, "Echo", payload, await_response=True)
+print(reply)
+```
+
+## Raw Packets
+
+When a real‑time link exists you can send arbitrary bytes using an
+`RNS.Packet`:
+
+```python
+import RNS
+
+dest = RNS.Destination(server_identity, RNS.Destination.OUT, RNS.Destination.SINGLE, "openapi", "link")
+link = RNS.Link(dest)
+RNS.Packet(link, b"status?").send()
+```
+
+## Resource Transfers
+
+Large binary data can be moved over the link with `RNS.Resource`:
+
+```python
+import RNS
+
+link = RNS.Link(dest)
+data = open("report.bin", "rb").read()
+RNS.Resource(data, link, callback=lambda r: print("transfer complete"))
+```
+


### PR DESCRIPTION
## Summary
- clarify when to use LXMF messages versus real-time links in README
- describe link establishment, keep-alive and resource transfers in framework design
- add API usage examples for commands, raw packets and resource transfers

## Testing
- `flake8 --exclude=venv_linux` *(fails: E303 too many blank lines, F401 'json' imported but unused, etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'runtime')*


------
https://chatgpt.com/codex/tasks/task_e_6899e7d558188325aa259dcad6b438a6