### PR TITLE
Refactor link utilities to resolve linter errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ See [docs/protocol_design.md](docs/protocol_design.md) for the protocol overview
 ## Resource transfers
 
 The package also includes helpers for sending and receiving larger files over Reticulum links. Use
-`LinkClient.send_resource()` to upload a file with progress reporting and
-`LinkService.resource_received_callback()` to store incoming resources in a chosen directory.
+`ResourceClient.send_resource()` to upload a file with progress reporting and
+`ResourceService.resource_received_callback()` to store incoming resources in a chosen directory.
 
 ## Quick start
 

--- a/reticulum_openapi/__init__.py
+++ b/reticulum_openapi/__init__.py
@@ -1,13 +1,15 @@
 """Reticulum OpenAPI package."""
 
-from .controller import Controller, APIException, handle_exceptions
-from .model import BaseModel, dataclass_from_json, dataclass_to_json
+from .controller import APIException
+from .controller import Controller
+from .controller import handle_exceptions
+from .model import BaseModel
+from .model import dataclass_from_json
+from .model import dataclass_to_json
 from .link_client import LinkClient
 from .link_service import LinkService
 from .service import LXMFService
 from .status import StatusCode
-from .link_client import LinkClient
-from .link_service import LinkService
 
 __all__ = [
     "Controller",
@@ -20,6 +22,4 @@ __all__ = [
     "LinkService",
     "LXMFService",
     "StatusCode",
-    "LinkClient",
-    "LinkService",
 ]

--- a/reticulum_openapi/link_service.py
+++ b/reticulum_openapi/link_service.py
@@ -1,20 +1,18 @@
-
 """Helpers for handling incoming resources on Reticulum links."""
 
+import asyncio
 import os
 import shutil
-from typing import Callable
-
-import asyncio
 from typing import Any
 from typing import Awaitable
 from typing import Callable
 from typing import Dict
 from typing import Optional
+
 import RNS
 
 
-class LinkService:
+class ResourceService:
     """Service utilities for receiving resources on a link."""
 
     def __init__(
@@ -61,7 +59,9 @@ class LinkService:
                 self.on_download_complete(dest_path)
         except Exception as exc:
             RNS.log(f"Failed to store resource: {exc}")
-            
+
+
+class LinkService:
     """Service accepting incoming ``RNS.Link`` connections."""
 
     def __init__(
@@ -139,5 +139,3 @@ class LinkService:
         for task in self._keepalive_tasks.values():
             task.cancel()
         self._keepalive_tasks.clear()
-
-        

--- a/tests/test_link_resources.py
+++ b/tests/test_link_resources.py
@@ -41,7 +41,7 @@ def test_send_resource_callbacks(monkeypatch, tmp_path):
     def hook(res):
         calls["hook"] = True
 
-    cli = link_client.LinkClient(fake_link, on_upload_complete=hook)
+    cli = link_client.ResourceClient(fake_link, on_upload_complete=hook)
     cli.send_resource(
         str(file_path), progress_callback=progress, completion_callback=completion
     )
@@ -59,14 +59,14 @@ def test_send_resource_raises(monkeypatch, tmp_path):
         raise ValueError("boom")
 
     monkeypatch.setattr(link_client.RNS, "Resource", raise_resource)
-    cli = link_client.LinkClient(object())
+    cli = link_client.ResourceClient(object())
     with pytest.raises(ValueError):
         cli.send_resource(str(file_path))
 
 
 def test_resource_received_callback(tmp_path):
     storage = tmp_path / "store"
-    service = link_service.LinkService(str(storage))
+    service = link_service.ResourceService(str(storage))
 
     src_path = tmp_path / "incoming"
     src_path.write_bytes(b"content")
@@ -87,7 +87,7 @@ def test_resource_received_callback_no_metadata(tmp_path):
     def hook(path):
         called["path"] = path
 
-    service = link_service.LinkService(str(storage), on_download_complete=hook)
+    service = link_service.ResourceService(str(storage), on_download_complete=hook)
 
     src_path = tmp_path / "incoming"
     src_path.write_bytes(b"data")


### PR DESCRIPTION
## Summary
- split resource helper classes into `ResourceClient` and `ResourceService`
- clean up imports and duplicate exports in package `__init__`
- fix LinkClient initialization race and update docs/tests

## Testing
- `flake8 reticulum_openapi tests`
- `pytest --cov=reticulum_openapi`

------
https://chatgpt.com/codex/tasks/task_e_6899fa1eacfc83259a0c3b151e659d5e