### PR TITLE
Fix flake8 violations

### DIFF
--- a/reticulum_openapi/link_client.py
+++ b/reticulum_openapi/link_client.py
@@ -1,8 +1,5 @@
-
 """Utilities for working with Reticulum links."""
 
-import os
-from typing import Callable
 import asyncio
 import os
 from dataclasses import asdict
@@ -12,12 +9,11 @@ from typing import Callable
 from typing import Optional
 
 import RNS
-from .model import dataclass_to_json
 
 from .model import dataclass_to_json
+
 
 class LinkFileClient:
-
     """Client helper for sending resources over an established link."""
 
     def __init__(
@@ -113,9 +109,6 @@ class LinkClient:
             closed_callback=self._on_closed,
         )
         self.link.set_packet_callback(self._handle_packet)
-
-        self.packet_queue: asyncio.Queue[bytes] = asyncio.Queue()
-
 
     def _on_established(self, _link: RNS.Link) -> None:
         """Internal callback when link is established."""

--- a/reticulum_openapi/link_service.py
+++ b/reticulum_openapi/link_service.py
@@ -2,16 +2,18 @@
 
 import asyncio
 import os
+import shutil
 
+from typing import Any
+from typing import Awaitable
 from typing import Callable
+from typing import Dict
+from typing import Optional
 
-import asyncio
-from typing import Any, Awaitable, Dict, Optional
 import RNS
 
 
 class LinkResourceService:
-
     """Service utilities for receiving resources on a link."""
 
     def __init__(
@@ -138,5 +140,3 @@ class LinkService:
         for task in self._keepalive_tasks.values():
             task.cancel()
         self._keepalive_tasks.clear()
-
-        

--- a/tests/test_link_client.py
+++ b/tests/test_link_client.py
@@ -80,7 +80,6 @@ async def test_send_serializes_dict(monkeypatch):
         lambda d: (captured.setdefault("payload", d), b"data")[1],
     )
 
-
     cli = lc_module.LinkClient("aa")
     await cli.send({"k": "v"})
     assert captured["payload"] == {"k": "v"}

--- a/tests/test_link_resources.py
+++ b/tests/test_link_resources.py
@@ -42,7 +42,6 @@ def test_send_resource_callbacks(monkeypatch, tmp_path):
     def hook(res):
         calls["hook"] = True
 
-
     cli = link_client.LinkFileClient(fake_link, on_upload_complete=hook)
 
     cli.send_resource(
@@ -62,6 +61,7 @@ def test_send_resource_raises(monkeypatch, tmp_path):
     def raise_resource(*a, **k):
         raise ValueError("boom")
 
+    monkeypatch.setattr(link_client.RNS, "Resource", raise_resource)
 
     cli = link_client.LinkFileClient(object())
 
@@ -74,7 +74,6 @@ def test_resource_received_callback(tmp_path):
     storage = tmp_path / "store"
 
     service = link_service.LinkResourceService(str(storage))
-
 
     src_path = tmp_path / "incoming"
     src_path.write_bytes(b"content")
@@ -96,9 +95,7 @@ def test_resource_received_callback_no_metadata(tmp_path):
     def hook(path):
         called["path"] = path
 
-
     service = link_service.LinkResourceService(str(storage), on_download_complete=hook)
-
 
     src_path = tmp_path / "incoming"
     src_path.write_bytes(b"data")


### PR DESCRIPTION
## Summary
- remove duplicate imports and redundant queue setup in link client
- clean up imports and add missing shutil import in link service
- tidy test spacing and restore monkeypatch in resource tests

## Testing
- `flake8 reticulum_openapi tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a0167c68c8325923bb7b675f011d5