### PR TITLE
docs: modernize generator tooling

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -2,3 +2,4 @@
 
 ## 2025-08-11
 - [x] Fix flake8 errors across the codebase.
+- [x] Update generator docs to use Python tooling and note post-generation tweaks.

--- a/examples/filmology/readme.md
+++ b/examples/filmology/readme.md
@@ -11,34 +11,43 @@ The API contract lives in [`API/FilmologyManagement-OAS.yaml`](API/FilmologyMana
 
 1. Install project dependencies from the repository root:
 
+ ```bash
+ pip install -r requirements.txt
+ ```
+
+2. Install `openapi-generator-cli` using the Python package or Docker.
+
 ```bash
-pip install -r requirements.txt
+pip install openapi-generator-cli
 ```
 
-2. Ensure you have `openapi-generator-cli` available. Install it via npm:
+Or run with Docker:
 
 ```bash
-npm install @openapitools/openapi-generator-cli -g
+docker run --rm -v "$PWD:/local" openapitools/openapi-generator-cli generate
 ```
 
 3. Generate the service and client using the provided templates:
 
-```bash
-openapi-generator-cli generate \
+ ```bash
+ openapi-generator-cli generate \
     -g python \
     -i examples/filmology/API/FilmologyManagement-OAS.yaml \
     -t templates \
     -o examples/filmology/FilmologyService
-```
+ ```
 
-4. Start the generated server:
+4. After generation, consider enabling `auth_token` in the service and client or
+   adding schemas not defined in the specification.
+
+5. Start the generated server:
 
 ```bash
 cd examples/filmology/FilmologyService
 python server.py
 ```
 
-5. In another terminal, run the generated client:
+6. In another terminal, run the generated client:
 
 ```bash
 python client.py

--- a/templates/README.md
+++ b/templates/README.md
@@ -4,13 +4,28 @@ These templates can be used with `openapi-generator-cli` to produce a working
 Reticulum LXMF service and client from an OpenAPI specification. The generated
 structure mirrors the `EmergencyManagement` example.
 
+## Installation
+
+Install the generator with the Python CLI or run it via Docker. Using the
+Python package:
+
+```bash
+pip install openapi-generator-cli
+```
+
+Or with Docker:
+
+```bash
+docker run --rm -v "$PWD:/local" openapitools/openapi-generator-cli generate
+```
+
 ## Usage
 
 ```bash
 openapi-generator-cli generate \
     -g python \
     -i path/to/spec.yaml \
-    -t path/to/templates \
+    -t templates \
     -o generated
 ```
 
@@ -24,3 +39,10 @@ The output will contain:
 - `database.py` – example async database setup
 
 Adjust the generated code as needed for your specification.
+
+### Post-generation adjustments
+
+- Set `auth_token` on the generated service and client if your deployment
+  requires message authentication.
+- Add additional schema dataclasses if your API defines objects outside the
+  supplied OpenAPI spec.


### PR DESCRIPTION
## Summary
- replace npm-based generator install instructions with Python/Docker alternatives
- point generator to current `templates/` layout
- document post-generation steps like enabling `auth_token`

## Testing
- `pytest` *(fails: FileNotFoundError in tests/test_link_resources.py::test_resource_received_callback)*

------
https://chatgpt.com/codex/tasks/task_e_689a0140f3f88325a97c9ff88e1ac10b