### PR TITLE
test: adjust codec msgpack import

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -4,4 +4,5 @@
 - [x] Fix flake8 errors across the codebase.
 - [x] Add loopback link tests for client requests and resource transfer.
 - [x] Update generator docs to use Python tooling and note post-generation tweaks.
+- [x] Update codec Msgpack test to import from reticulum_openapi.
 

--- a/tests/test_codec_msgpack.py
+++ b/tests/test_codec_msgpack.py
@@ -1,7 +1,7 @@
 import importlib
 import pytest
 
-from reticulum_openapi import codec_msgpack as codec
+import reticulum_openapi.codec_msgpack as codec
 
 
 def test_basic_integers():


### PR DESCRIPTION
## Summary
- update codec_msgpack test to import from reticulum_openapi module
- track task for updating codec Msgpack test import

## Testing
- `pytest tests/test_codec_msgpack.py`

------
https://chatgpt.com/codex/tasks/task_e_689a08d7c7508325b363739982c8305b