### PR TITLE
Clarify update return type

### DIFF
--- a/examples/EmergencyManagement/Server/controllers_emergency.py
+++ b/examples/EmergencyManagement/Server/controllers_emergency.py
@@ -1,10 +1,10 @@
 from dataclasses import asdict
-from reticulum_openapi.controller import Controller, handle_exceptions
+from typing import Optional
+from reticulum_openapi.controller import Controller
+from reticulum_openapi.controller import handle_exceptions
 from examples.EmergencyManagement.Server.database import async_session
-from examples.EmergencyManagement.Server.models_emergency import (
-    EmergencyActionMessage,
-    Event,
-)
+from examples.EmergencyManagement.Server.models_emergency import EmergencyActionMessage
+from examples.EmergencyManagement.Server.models_emergency import Event
 
 
 class EmergencyController(Controller):
@@ -30,10 +30,22 @@ class EmergencyController(Controller):
         return items
 
     @handle_exceptions
-    async def PutEmergencyActionMessage(self, req: EmergencyActionMessage):
+    async def PutEmergencyActionMessage(
+        self, req: EmergencyActionMessage
+    ) -> Optional[EmergencyActionMessage]:
+        """Update an existing emergency action message.
+
+        Args:
+            req (EmergencyActionMessage): New values for the message.
+
+        Returns:
+            Optional[EmergencyActionMessage]: Updated dataclass instance or ``None`` if not found.
+        """
         self.logger.info(f"PutEAM: {req}")
         async with async_session() as session:
-            updated = await EmergencyActionMessage.update(session, req.callsign, **asdict(req))
+            updated = await EmergencyActionMessage.update(
+                session, req.callsign, **asdict(req)
+            )
         return updated
 
     @handle_exceptions
@@ -67,7 +79,15 @@ class EventController(Controller):
         return events
 
     @handle_exceptions
-    async def PutEvent(self, req: Event):
+    async def PutEvent(self, req: Event) -> Optional[Event]:
+        """Update an event record.
+
+        Args:
+            req (Event): New values for the event.
+
+        Returns:
+            Optional[Event]: Updated dataclass instance or ``None`` if not found.
+        """
         self.logger.info(f"PutEvent: {req}")
         async with async_session() as session:
             updated = await Event.update(session, req.uid, **asdict(req))

--- a/reticulum_openapi/model.py
+++ b/reticulum_openapi/model.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass, asdict, is_dataclass, fields
 import json
 import zlib
-from typing import Type, TypeVar, get_origin, get_args, Union
+from typing import Type, TypeVar, get_origin, get_args, Union, Optional, List
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from sqlalchemy import select
 
@@ -14,7 +14,7 @@ __all__ = [
     "async_sessionmaker",
 ]
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 def dataclass_to_json(data_obj: T) -> bytes:
@@ -29,7 +29,7 @@ def dataclass_to_json(data_obj: T) -> bytes:
         data_dict = data_obj
     json_str = json.dumps(data_dict)
     # Compress the JSON bytes to minimize payload size
-    json_bytes = json_str.encode('utf-8')
+    json_bytes = json_str.encode("utf-8")
     compressed = zlib.compress(json_bytes)
     return compressed
 
@@ -43,7 +43,7 @@ def dataclass_from_json(cls: Type[T], data: bytes) -> T:
     except zlib.error:
         # Data might not be compressed; use raw bytes if decompression fails
         json_bytes = data
-    json_str = json_bytes.decode('utf-8')
+    json_str = json_bytes.decode("utf-8")
     obj_dict = json.loads(json_str)
 
     def _construct(tp, value):
@@ -75,6 +75,7 @@ class BaseModel:
     Base data model providing serialization utilities and generic CRUD operations
     if __orm_model__ is defined on subclasses.
     """
+
     # Subclasses should set this to their SQLAlchemy ORM model class
     __orm_model__ = None
 
@@ -108,7 +109,9 @@ class BaseModel:
         Returns the dataclass instance.
         """
         if cls.__orm_model__ is None:
-            raise NotImplementedError("Subclasses must define __orm_model__ for persistence")
+            raise NotImplementedError(
+                "Subclasses must define __orm_model__ for persistence"
+            )
         obj = cls.__orm_model__(**kwargs)
         session.add(obj)
         await session.commit()
@@ -116,27 +119,38 @@ class BaseModel:
         return cls.from_orm(obj)
 
     @classmethod
-    async def get(cls, session: AsyncSession, id_):
-        """
-        Retrieve a record by primary key using the ORM model.
-        Returns the ORM instance or None.
+    async def get(cls, session: AsyncSession, id_) -> Optional[T]:
+        """Retrieve a record by primary key.
+
+        Args:
+            session (AsyncSession): Database session.
+            id_: Primary key of the record to fetch.
+
+        Returns:
+            Optional[T]: Dataclass instance or ``None`` if not found.
         """
         if cls.__orm_model__ is None:
-            raise NotImplementedError("Subclasses must define __orm_model__ for persistence")
+            raise NotImplementedError(
+                "Subclasses must define __orm_model__ for persistence"
+            )
         orm_obj = await session.get(cls.__orm_model__, id_)
         if orm_obj is None:
             return None
         return cls.from_orm(orm_obj)
 
     @classmethod
-    async def list(cls, session: AsyncSession, **filters):
-        """
-        List records matching given filters using the ORM model.
+    async def list(cls, session: AsyncSession, **filters) -> List[T]:
+        """List records matching given filters.
+
         Filters should correspond to model attributes.
-        Returns a list of ORM instances.
+
+        Returns:
+            List[T]: Dataclass instances matching the filters.
         """
         if cls.__orm_model__ is None:
-            raise NotImplementedError("Subclasses must define __orm_model__ for persistence")
+            raise NotImplementedError(
+                "Subclasses must define __orm_model__ for persistence"
+            )
         stmt = select(cls.__orm_model__)
         for attr, value in filters.items():
             stmt = stmt.where(getattr(cls.__orm_model__, attr) == value)
@@ -144,13 +158,21 @@ class BaseModel:
         return [cls.from_orm(obj) for obj in result.scalars().all()]
 
     @classmethod
-    async def update(cls, session: AsyncSession, id_, **kwargs):
-        """
-        Update fields of a record identified by primary key.
-        Returns the updated ORM instance or None if not found.
+    async def update(cls, session: AsyncSession, id_, **kwargs) -> Optional[T]:
+        """Update fields on a record by primary key.
+
+        Args:
+            session (AsyncSession): Database session.
+            id_: Primary key of the record to update.
+            **kwargs: Fields and values to set on the record.
+
+        Returns:
+            Optional[T]: Updated dataclass instance or ``None`` if not found.
         """
         if cls.__orm_model__ is None:
-            raise NotImplementedError("Subclasses must define __orm_model__ for persistence")
+            raise NotImplementedError(
+                "Subclasses must define __orm_model__ for persistence"
+            )
         orm_obj = await session.get(cls.__orm_model__, id_)
         if orm_obj is None:
             return None
@@ -162,13 +184,15 @@ class BaseModel:
         return cls.from_orm(orm_obj)
 
     @classmethod
-    async def delete(cls, session: AsyncSession, id_):
+    async def delete(cls, session: AsyncSession, id_) -> bool:
         """
         Delete a record by primary key.
         Returns True if deleted, False if not found.
         """
         if cls.__orm_model__ is None:
-            raise NotImplementedError("Subclasses must define __orm_model__ for persistence")
+            raise NotImplementedError(
+                "Subclasses must define __orm_model__ for persistence"
+            )
         orm_obj = await session.get(cls.__orm_model__, id_)
         if orm_obj is None:
             return False

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -25,16 +25,20 @@ class Item(BaseModel):
 @pytest.mark.asyncio
 async def test_crud_roundtrip():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async_session = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     async with async_session() as session:
         await Item.create(session, id=1, name="foo")
         item = await Item.get(session, 1)
         assert item.name == "foo"
-        await Item.update(session, 1, name="bar")
-        updated = await Item.get(session, 1)
+        updated = await Item.update(session, 1, name="bar")
+        assert isinstance(updated, Item)
         assert updated.name == "bar"
+        retrieved = await Item.get(session, 1)
+        assert retrieved.name == "bar"
         items = await Item.list(session)
         assert len(items) == 1
         assert items[0].name == "bar"


### PR DESCRIPTION
## Summary
- Document BaseModel.update returning an updated dataclass instance or None
- Note dataclass return types in emergency controller update endpoints
- Add tests asserting update yields dataclass objects

## Testing
- `flake8 reticulum_openapi/model.py examples/EmergencyManagement/Server/controllers_emergency.py tests/test_persistence.py tests/test_model.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689526c6a7b0832591f3fe014ffb3b11