### PR TITLE
Decode EmergencyManagement client responses using MessagePack

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -2,3 +2,5 @@
 
 ## 2025-08-11
 - [x] Fix flake8 errors across the codebase.
+- [x] Decode command responses into dataclasses in EmergencyManagement client.
+- [x] Implement MessagePack decoding in EmergencyManagement client.

--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -1,5 +1,7 @@
 import asyncio
+
 from reticulum_openapi.client import LXMFClient
+from reticulum_openapi.codec_msgpack import from_bytes
 from examples.EmergencyManagement.Server.models_emergency import (
     EmergencyActionMessage,
     EAMStatus,
@@ -7,19 +9,33 @@ from examples.EmergencyManagement.Server.models_emergency import (
 
 
 async def main():
+    """Send and retrieve an emergency action message.
+
+    Prompts the user for a server identity hash, sends an emergency action
+    message, and then retrieves the stored message for demonstration.
+    Responses from the server are decoded from MessagePack into dataclasses
+    before printing.
+    """
+
     client = LXMFClient()
     server_id = input("Server Identity Hash: ")
     eam = EmergencyActionMessage(
-        callsign="Bravo1", groupName="Bravo",
-        securityStatus=EAMStatus.Green, securityCapability=EAMStatus.Green,
-        preparednessStatus=EAMStatus.Green, medicalStatus=EAMStatus.Green,
-        mobilityStatus=EAMStatus.Green, commsStatus=EAMStatus.Green,
-        commsMethod="VOIP"
+        callsign="Bravo1",
+        groupName="Bravo",
+        securityStatus=EAMStatus.Green,
+        securityCapability=EAMStatus.Green,
+        preparednessStatus=EAMStatus.Green,
+        medicalStatus=EAMStatus.Green,
+        mobilityStatus=EAMStatus.Green,
+        commsStatus=EAMStatus.Green,
+        commsMethod="VOIP",
     )
     resp = await client.send_command(
         server_id, "CreateEmergencyActionMessage", eam, await_response=True
     )
-    print("Create response:", resp)
+    # Decode MessagePack bytes into a dataclass for readability
+    created_eam = EmergencyActionMessage(**from_bytes(resp))
+    print("Create response:", created_eam)
 
     # Retrieve the message back from the server to demonstrate persistence
     retrieved = await client.send_command(
@@ -28,7 +44,10 @@ async def main():
         eam.callsign,
         await_response=True,
     )
-    print("Retrieve response:", retrieved)
+    # Convert MessagePack bytes to an EmergencyActionMessage dataclass
+    retrieved_eam = EmergencyActionMessage(**from_bytes(retrieved))
+    print("Retrieve response:", retrieved_eam)
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- decode server responses with MessagePack and instantiate `EmergencyActionMessage` dataclasses in the EmergencyManagement client
- log MessagePack decoding completion in the task list

## Testing
- `flake8 examples/EmergencyManagement/client/client_emergency.py`
- `pytest` *(fails: tests/test_link_resources.py::test_send_resource_raises, tests/test_link_resources.py::test_resource_received_callback, tests/test_link_resources.py::test_resource_received_callback_no_metadata)*

------
https://chatgpt.com/codex/tasks/task_e_689a013965fc8325972b134379d34bc0