### PR TITLE
Use MessagePack for model serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Reticulum OpenAPI is an experimental framework for building lightweight APIs on 
 
 This repository contains the Python implementation of the framework as well as documentation, a full featured example and generator templates. The goal is to provide an easy way to build applications that communicate over Reticulum using structured messages.
 
+Models and payloads are serialized with MessagePack to minimize bandwidth overhead.
+
 The project now also exposes primitives for maintaining persistent links via
 ``LinkClient`` and ``LinkService`` which allow direct communication over an
 ``RNS.Link`` in addition to LXMF messaging.

--- a/TASK.md
+++ b/TASK.md
@@ -5,4 +5,6 @@
 - [x] Add loopback link tests for client requests and resource transfer.
 - [x] Update generator docs to use Python tooling and note post-generation tweaks.
 - [x] Update codec Msgpack test to import from reticulum_openapi.
+- [x] Use MessagePack for dataclass serialization and drop zlib compression.
+- [x] Rename serialization helpers to dataclass_to_msgpack/from_msgpack for clarity.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest
 pytest-asyncio
 flake8
 aiosqlite
+msgpack

--- a/reticulum_openapi/__init__.py
+++ b/reticulum_openapi/__init__.py
@@ -4,8 +4,8 @@ from .controller import APIException
 from .controller import Controller
 from .controller import handle_exceptions
 from .model import BaseModel
-from .model import dataclass_from_json
-from .model import dataclass_to_json
+from .model import dataclass_from_msgpack
+from .model import dataclass_to_msgpack
 from .link_client import LinkClient
 from .link_service import LinkService
 from .service import LXMFService
@@ -16,8 +16,8 @@ __all__ = [
     "APIException",
     "handle_exceptions",
     "BaseModel",
-    "dataclass_from_json",
-    "dataclass_to_json",
+    "dataclass_from_msgpack",
+    "dataclass_to_msgpack",
     "LinkClient",
     "LinkService",
     "LXMFService",

--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -5,7 +5,7 @@ from dataclasses import asdict
 from dataclasses import is_dataclass
 from typing import Optional
 from typing import Dict
-from .model import dataclass_to_json
+from .model import dataclass_to_msgpack
 
 
 class LXMFClient:
@@ -79,7 +79,7 @@ class LXMFClient:
             if self.auth_token:
 
                 data_dict["auth_token"] = self.auth_token
-            content_bytes = dataclass_to_json(data_dict)
+            content_bytes = dataclass_to_msgpack(data_dict)
         lxmsg = LXMF.LXMessage(
             RNS.Destination(
                 dest_identity,

--- a/reticulum_openapi/link_client.py
+++ b/reticulum_openapi/link_client.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 import RNS
 
-from .model import dataclass_to_json
+from .model import dataclass_to_msgpack
 
 
 class LinkFileClient:
@@ -130,14 +130,14 @@ class LinkClient:
 
         Args:
             data (Any): Payload to transmit. If not ``bytes`` it will be
-                serialised using :func:`dataclass_to_json`.
+                serialised using :func:`dataclass_to_msgpack`.
         """
         if isinstance(data, bytes):
             payload = data
         else:
             if is_dataclass(data):
                 data = asdict(data)
-            payload = dataclass_to_json(data)
+            payload = dataclass_to_msgpack(data)
         self.link.send(payload)
 
     async def request(
@@ -148,7 +148,7 @@ class LinkClient:
         Args:
             path (str): Remote path string.
             data (Any, optional): Optional payload. Uses
-                :func:`dataclass_to_json` if not ``bytes``. Defaults to ``None``.
+                :func:`dataclass_to_msgpack` if not ``bytes``. Defaults to ``None``.
             timeout (float, optional): Request timeout in seconds. Defaults to
                 ``None`` letting Reticulum choose.
 
@@ -163,7 +163,7 @@ class LinkClient:
         else:
             if is_dataclass(data):
                 data = asdict(data)
-            payload = dataclass_to_json(data)
+            payload = dataclass_to_msgpack(data)
 
         fut: asyncio.Future[bytes] = self._loop.create_future()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 import asyncio
 from dataclasses import dataclass
 from types import SimpleNamespace
+import msgpack
 import pytest
 
 from reticulum_openapi import client as client_module
@@ -126,21 +127,18 @@ async def test_send_command_includes_token(monkeypatch):
 
     call_counter = {"count": 0}
 
-    original_dc_to_json = client_module.dataclass_to_json
+    original_dc_to_msgpack = client_module.dataclass_to_msgpack
 
-    def fake_dataclass_to_json(obj):
+    def fake_dataclass_to_msgpack(obj):
         call_counter["count"] += 1
         captured["pre"] = obj
-        return original_dc_to_json(obj)
+        return original_dc_to_msgpack(obj)
 
-    monkeypatch.setattr(client_module, "dataclass_to_json", fake_dataclass_to_json)
+    monkeypatch.setattr(client_module, "dataclass_to_msgpack", fake_dataclass_to_msgpack)
 
     await cli.send_command("aa", "CMD", Sample(text="hello"), await_response=False)
 
-    import json
-    import zlib
-
-    payload = json.loads(zlib.decompress(captured["content"]).decode())
+    payload = msgpack.unpackb(captured["content"], raw=False)
     assert payload.get("auth_token") == "secret"
     assert payload.get("text") == "hello"
     assert call_counter["count"] == 1

--- a/tests/test_link_client.py
+++ b/tests/test_link_client.py
@@ -78,7 +78,7 @@ async def test_send_serializes_dict(monkeypatch):
 
     monkeypatch.setattr(
         lc_module,
-        "dataclass_to_json",
+        "dataclass_to_msgpack",
         lambda d: (captured.setdefault("payload", d), b"data")[1],
     )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,8 +8,8 @@ from sqlalchemy import String
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession
-from reticulum_openapi.model import dataclass_to_json
-from reticulum_openapi.model import dataclass_from_json
+from reticulum_openapi.model import dataclass_to_msgpack
+from reticulum_openapi.model import dataclass_from_msgpack
 from reticulum_openapi.model import BaseModel
 
 
@@ -26,15 +26,15 @@ class ItemList:
 
 def test_serialization_roundtrip():
     item = Item(name="foo", value=42)
-    data = dataclass_to_json(item)
-    obj = dataclass_from_json(Item, data)
+    data = dataclass_to_msgpack(item)
+    obj = dataclass_from_msgpack(Item, data)
     assert obj == item
 
 
 def test_list_of_items_roundtrip():
     obj = ItemList(items=[Item(name="a", value=1), Item(name="b", value=2)])
-    data = dataclass_to_json(obj)
-    reconstructed = dataclass_from_json(ItemList, data)
+    data = dataclass_to_msgpack(obj)
+    reconstructed = dataclass_from_msgpack(ItemList, data)
     assert reconstructed == obj
 
 
@@ -63,16 +63,16 @@ class TransportRecord:
 
 
 def test_union_deserialization_root():
-    data = dataclass_to_json(Car(manufacturer="Acme", doors=2))
-    obj = dataclass_from_json(Vehicle, data)
+    data = dataclass_to_msgpack(Car(manufacturer="Acme", doors=2))
+    obj = dataclass_from_msgpack(Vehicle, data)
     assert isinstance(obj, Car)
     assert obj.doors == 2
 
 
 def test_union_deserialization_nested():
     record = TransportRecord(owner="bob", vehicle=Bike(handlebar="drop"))
-    data = dataclass_to_json(record)
-    obj = dataclass_from_json(TransportRecord, data)
+    data = dataclass_to_msgpack(record)
+    obj = dataclass_from_msgpack(TransportRecord, data)
     assert isinstance(obj.vehicle, Bike)
 
 

--- a/tests/test_model_extra.py
+++ b/tests/test_model_extra.py
@@ -1,8 +1,7 @@
-import json
 from dataclasses import dataclass
 from typing import Union
-
 import pytest
+import msgpack
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -12,8 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from reticulum_openapi.model import BaseModel
 from reticulum_openapi.model import async_sessionmaker
 from reticulum_openapi.model import create_async_engine
-from reticulum_openapi.model import dataclass_from_json
-from reticulum_openapi.model import dataclass_to_json
+from reticulum_openapi.model import dataclass_from_msgpack
+from reticulum_openapi.model import dataclass_to_msgpack
 
 
 Base = declarative_base()
@@ -57,22 +56,22 @@ class Bike:
 Vehicle = Union[Car, Bike]
 
 
-def test_dataclass_from_json_uncompressed():
-    data = json.dumps({"name": "foo", "value": 1}).encode()
-    obj = dataclass_from_json(Simple, data)
+def test_dataclass_from_msgpack():
+    data = msgpack.packb({"name": "foo", "value": 1}, use_bin_type=True)
+    obj = dataclass_from_msgpack(Simple, data)
     assert obj == Simple(name="foo", value=1)
 
 
 def test_union_deserialization_error():
-    bad = dataclass_to_json({"foo": "bar"})
+    bad = dataclass_to_msgpack({"foo": "bar"})
     with pytest.raises(ValueError):
-        dataclass_from_json(Vehicle, bad)
+        dataclass_from_msgpack(Vehicle, bad)
 
 
 def test_base_model_to_json_and_from():
     item = Item(id=1, name="a")
-    data = item.to_json_bytes()
-    restored = Item.from_json_bytes(data)
+    data = item.to_msgpack()
+    restored = Item.from_msgpack(data)
     assert restored == item
 
 
@@ -101,7 +100,9 @@ async def test_methods_without_orm_raise():
 @pytest.mark.asyncio
 async def test_crud_edge_cases():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    session_maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    session_maker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     async with session_maker() as session:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,14 +1,13 @@
 import asyncio
-import json
-import zlib
 from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import msgpack
 import pytest
 
 from reticulum_openapi.service import LXMFService
-from reticulum_openapi.model import dataclass_to_json
+from reticulum_openapi.model import dataclass_to_msgpack
 
 
 @dataclass
@@ -34,7 +33,7 @@ async def test_lxmf_callback_decodes_dataclass_and_dispatches():
     service._routes = {"CMD": (handler, Sample, None)}
 
     message = SimpleNamespace(
-        title="CMD", content=dataclass_to_json(Sample(text="hello")), source=None
+        title="CMD", content=dataclass_to_msgpack(Sample(text="hello")), source=None
     )
 
     service._lxmf_delivery_callback(message)
@@ -70,7 +69,7 @@ async def test_lxmf_callback_schema_validation():
 
     valid_msg = SimpleNamespace(
         title="SCHEMA",
-        content=zlib.compress(json.dumps({"num": 5}).encode()),
+        content=dataclass_to_msgpack({"num": 5}),
         source=None,
     )
     service._lxmf_delivery_callback(valid_msg)
@@ -80,7 +79,7 @@ async def test_lxmf_callback_schema_validation():
     called = False
     invalid_msg = SimpleNamespace(
         title="SCHEMA",
-        content=zlib.compress(json.dumps({"num": "bad"}).encode()),
+        content=dataclass_to_msgpack({"num": "bad"}),
         source=None,
     )
     service._lxmf_delivery_callback(invalid_msg)
@@ -115,7 +114,7 @@ async def test_lxmf_callback_dispatches_response():
     dest, title, payload_bytes = send_mock.call_args.args[:3]
     assert dest is src
     assert title == "PING_response"
-    assert json.loads(zlib.decompress(payload_bytes).decode()) == {"status": "ok"}
+    assert msgpack.unpackb(payload_bytes, raw=False) == {"status": "ok"}
 
 
 def test_get_api_specification_returns_registered_routes():

--- a/tests/test_service_extra.py
+++ b/tests/test_service_extra.py
@@ -1,11 +1,10 @@
 import asyncio
-import json
-import zlib
 from types import SimpleNamespace
 from unittest.mock import Mock
 import pytest
 
 from reticulum_openapi import service as service_module
+from reticulum_openapi.model import dataclass_to_msgpack
 from dataclasses import dataclass
 
 
@@ -93,6 +92,7 @@ async def test_send_lxmf_uses_router(monkeypatch):
             self.src = src
             self.content = content
             self.title = title
+
     monkeypatch.setattr(service_module.RNS, "Destination", FakeDestination)
     monkeypatch.setattr(service_module.LXMF, "LXMessage", FakeLXMessage)
     svc._send_lxmf(object(), "CMD", b"data")
@@ -140,7 +140,7 @@ async def test_context_manager(monkeypatch):
 @pytest.mark.asyncio
 async def test_init_and_add_route(monkeypatch):
     class FakeReticulum:
-        storagepath = '/tmp'
+        storagepath = "/tmp"
 
         def __init__(self, config_path=None):
             pass
@@ -149,7 +149,7 @@ async def test_init_and_add_route(monkeypatch):
 
         def __init__(self):
 
-            self.hash = b'h'
+            self.hash = b"h"
 
     class FakeRNS:
         Reticulum = FakeReticulum
@@ -161,7 +161,7 @@ async def test_init_and_add_route(monkeypatch):
 
         @staticmethod
         def prettyhexrep(x):
-            return 'h'
+            return "h"
 
     class FakeLXMRouter:
 
@@ -177,12 +177,13 @@ async def test_init_and_add_route(monkeypatch):
     class FakeLXMF:
         LXMRouter = FakeLXMRouter
         LXMessage = object
-    monkeypatch.setattr(service_module, 'RNS', FakeRNS)
-    monkeypatch.setattr(service_module, 'LXMF', FakeLXMF)
+
+    monkeypatch.setattr(service_module, "RNS", FakeRNS)
+    monkeypatch.setattr(service_module, "LXMF", FakeLXMF)
     svc = service_module.LXMFService()
     assert isinstance(svc.router, FakeLXMRouter)
-    svc.add_route('PING', lambda: None)
-    assert 'PING' in svc._routes
+    svc.add_route("PING", lambda: None)
+    assert "PING" in svc._routes
 
 
 @pytest.mark.asyncio
@@ -205,7 +206,7 @@ def test_lxmf_delivery_callback_no_route(monkeypatch):
     assert any("No route" in m for m in logs)
 
 
-def test_lxmf_delivery_invalid_json(monkeypatch):
+def test_lxmf_delivery_invalid_msgpack(monkeypatch):
     async def handler(payload):
         return None
 
@@ -216,10 +217,10 @@ def test_lxmf_delivery_invalid_json(monkeypatch):
     svc.auth_token = None
     logs = []
     monkeypatch.setattr(service_module.RNS, "log", lambda msg: logs.append(msg))
-    bad = zlib.compress(b"not-json")
+    bad = b"not-msgpack"
     message = SimpleNamespace(title="CMD", content=bad)
     svc._lxmf_delivery_callback(message)
-    assert any("Invalid JSON" in m for m in logs)
+    assert any("Invalid MessagePack" in m for m in logs)
 
 
 @pytest.mark.asyncio
@@ -236,7 +237,7 @@ async def test_lxmf_delivery_auth_failure(monkeypatch):
     monkeypatch.setattr(
         svc._loop, "call_soon_threadsafe", lambda fn: called.update(flag=True)
     )
-    payload = zlib.compress(json.dumps({"auth_token": "wrong"}).encode())
+    payload = dataclass_to_msgpack({"auth_token": "wrong"})
     message = SimpleNamespace(title="CMD", content=payload)
     svc._lxmf_delivery_callback(message)
     assert called["flag"] is False
@@ -255,7 +256,7 @@ async def test_lxmf_delivery_handler_exception(monkeypatch):
     monkeypatch.setattr(service_module.RNS, "log", lambda *a, **k: None)
     message = SimpleNamespace(
         title="CMD",
-        content=zlib.compress(json.dumps({}).encode()),
+        content=dataclass_to_msgpack({}),
         source=None,
     )
     svc._send_lxmf = Mock()


### PR DESCRIPTION
## Summary
- rename dataclass serialization helpers to dataclass_to_msgpack/from_msgpack with deprecated JSON wrappers
- update LXMF service, client utilities, and tests to use new MessagePack helpers
- document helper rename in TASK.md

## Testing
- `flake8 reticulum_openapi tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a367e7d3c83258bce909f9152bea8