### PR TITLE
Fix style regressions and dataclass utilities

### DIFF
--- a/reticulum_openapi/controller.py
+++ b/reticulum_openapi/controller.py
@@ -1,7 +1,6 @@
 import logging
-from typing import Callable, Any, Coroutine, TypeVar
+from typing import Any, Callable, Coroutine, TypeVar
 from functools import wraps
-
 
 # pretty sure every import of this class will trigger a new addHandler event which will result
 # in as many duplicate handlers for the controller logger as there are imports.
@@ -28,10 +27,8 @@ class APIException(Exception):
 F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
 
 
-# requires functools.wraps decorator
 def handle_exceptions(func: F) -> F:
     """Decorator to wrap controller methods with logging and exception handling."""
-
 
     @wraps(func)
     async def wrapper(*args, **kwargs):
@@ -59,7 +56,7 @@ class Controller:
     on endpoint methods to ensure consistent behavior.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = logger
 
     # As far as I can tell this isn't actually being used anywhere though maybe I'm missing something.

--- a/reticulum_openapi/link_client.py
+++ b/reticulum_openapi/link_client.py
@@ -114,7 +114,6 @@ class LinkClient:
         self.link.set_packet_callback(self._handle_packet)
         self.packet_queue: asyncio.Queue[bytes] = asyncio.Queue()
 
-
     def _on_established(self, _link: RNS.Link) -> None:
         """Internal callback when link is established."""
         self.established.set()

--- a/reticulum_openapi/model.py
+++ b/reticulum_openapi/model.py
@@ -3,17 +3,15 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import fields
 from dataclasses import is_dataclass
+from typing import List
+from typing import Optional
 from typing import Type
 from typing import TypeVar
-from typing import get_origin
-from typing import get_args
 from typing import Union
-from typing import Optional
-from typing import List
+from typing import get_args
+from typing import get_origin
 
 import msgpack
-
-
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -30,7 +28,6 @@ __all__ = [
 ]
 
 T = TypeVar("T")
-
 
 
 def dataclass_to_msgpack(data_obj: T) -> bytes:
@@ -55,8 +52,6 @@ def dataclass_to_json(data_obj: T) -> bytes:
     return dataclass_to_msgpack(data_obj)
 
 
-    return msgpack.packb(data_dict, use_bin_type=True)
-
 def dataclass_from_msgpack(cls: Type[T], data: bytes) -> T:
     """Deserialize a dataclass instance from MessagePack bytes.
 
@@ -67,10 +62,6 @@ def dataclass_from_msgpack(cls: Type[T], data: bytes) -> T:
     Returns:
         T: Instance of ``cls`` populated with decoded data.
     """
-
-def dataclass_from_json(cls: Type[T], data: bytes) -> T:
-    """Deserialize a dataclass instance from MessagePack bytes."""
-
 
     obj_dict = msgpack.unpackb(data, raw=False)
 
@@ -121,7 +112,6 @@ class BaseModel:
         return dataclass_to_msgpack(self)
 
     def to_json_bytes(self) -> bytes:
-
         """Deprecated wrapper for :meth:`to_msgpack`."""
         return self.to_msgpack()
 
@@ -141,15 +131,6 @@ class BaseModel:
     def from_json_bytes(cls: Type[T], data: bytes) -> T:
         """Deprecated wrapper for :meth:`from_msgpack`."""
         return cls.from_msgpack(data)
-
-        """Serialize this dataclass to MessagePack bytes."""
-        return dataclass_to_json(self)
-
-    @classmethod
-    def from_json_bytes(cls: Type[T], data: bytes) -> T:
-        """Deserialize MessagePack bytes to a dataclass instance."""
-        return dataclass_from_json(cls, data)
-
 
     def to_orm(self):
         """Create an ORM instance from this dataclass."""

--- a/tests/test_client_extra.py
+++ b/tests/test_client_extra.py
@@ -1,8 +1,6 @@
 import asyncio
 from types import SimpleNamespace
 
-
-
 import msgpack
 import pytest
 
@@ -140,7 +138,9 @@ async def test_send_command_dict_payload(monkeypatch):
         captured["obj"] = obj
         return original(obj)
 
-    monkeypatch.setattr(client_module, "dataclass_to_msgpack", fake_dataclass_to_msgpack)
+    monkeypatch.setattr(
+        client_module, "dataclass_to_msgpack", fake_dataclass_to_msgpack
+    )
 
     await cli.send_command("aa", "CMD", {"x": 1}, await_response=False)
 

--- a/tests/test_model_extra.py
+++ b/tests/test_model_extra.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Union
+
 import pytest
 import msgpack
 from sqlalchemy import Column
@@ -13,7 +14,6 @@ from reticulum_openapi.model import async_sessionmaker
 from reticulum_openapi.model import create_async_engine
 from reticulum_openapi.model import dataclass_from_msgpack
 from reticulum_openapi.model import dataclass_to_msgpack
-
 
 Base = declarative_base()
 
@@ -54,7 +54,6 @@ class Bike:
 
 
 Vehicle = Union[Car, Bike]
-
 
 
 def test_dataclass_from_msgpack():


### PR DESCRIPTION
## Summary
- tidy controller and link client formatting to satisfy flake8
- restore dataclass MessagePack helpers and clean BaseModel wrappers
- normalize test module imports for flake8 compliance

## Testing
- `flake8 reticulum_openapi/controller.py reticulum_openapi/link_client.py reticulum_openapi/model.py tests/test_client_extra.py tests/test_model_extra.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a4fe6f60c8325bc4f96905d8c83f0