### PR TITLE
Track LXMF responses with explicit request IDs

### DIFF
--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -1,16 +1,25 @@
 import asyncio
-import RNS
+import uuid
 import LXMF
-from typing import Optional, Dict
-from .model import dataclass_to_json, dataclass_from_json
+import RNS
+from typing import Dict
+from typing import Optional
+from .model import dataclass_from_json
+from .model import dataclass_to_json
 
 
 class LXMFClient:
     """Simple client for sending commands and awaiting responses."""
 
-    def __init__(self, config_path: str = None, storage_path: str = None,
-                 identity: RNS.Identity = None, display_name: str = "OpenAPIClient",
-                 auth_token: str = None, timeout: float = 10.0):
+    def __init__(
+        self,
+        config_path: str = None,
+        storage_path: str = None,
+        identity: RNS.Identity = None,
+        display_name: str = "OpenAPIClient",
+        auth_token: str = None,
+        timeout: float = 10.0,
+    ):
         self.reticulum = RNS.Reticulum(config_path)
         storage_path = storage_path or (RNS.Reticulum.storagepath + "/lxmf_client")
         self.router = LXMF.LXMRouter(storagepath=storage_path)
@@ -27,13 +36,50 @@ class LXMFClient:
         self.timeout = timeout
 
     def _callback(self, message: LXMF.LXMessage):
-        title = message.title
-        future = self._futures.pop(title, None)
-        if future is not None and not future.done():
-            future.set_result(message.content)
+        """Handle inbound messages and resolve any waiting futures.
 
-    async def send_command(self, dest_hex: str, command: str, payload_obj=None,
-                           await_response: bool = True, response_title: Optional[str] = None):
+        Args:
+            message (LXMF.LXMessage): Incoming message potentially containing a
+                ``request_id`` field referencing a previous request.
+
+        """
+
+        request_id = None
+        if hasattr(message, "fields") and isinstance(message.fields, dict):
+            request_id = message.fields.get("request_id")
+        if request_id is not None:
+            future = self._futures.pop(request_id, None)
+            if future is not None and not future.done():
+                future.set_result(message.content)
+
+    async def send_command(
+        self,
+        dest_hex: str,
+        command: str,
+        payload_obj=None,
+        await_response: bool = True,
+        response_title: Optional[str] = None,
+    ):
+        """Send a command to a remote peer.
+
+        A unique ``request_id`` is generated for each invocation. If
+        ``await_response`` is ``True`` the coroutine waits for a response
+        carrying the same ``request_id``.
+
+        Args:
+            dest_hex (str): Destination hash in hexadecimal representation.
+            command (str): Command title to include in the message.
+            payload_obj (Any, optional): Dataclass or bytes payload. Defaults to
+                ``None``.
+            await_response (bool, optional): Whether to wait for a response.
+                Defaults to ``True``.
+            response_title (Optional[str], optional): Deprecated, ignored
+                parameter. Defaults to ``None``.
+
+        Returns:
+            Optional[bytes]: Response bytes if ``await_response`` is ``True`` and
+            a response is received before timeout, otherwise ``None``.
+        """
         dest_hash = bytes.fromhex(dest_hex)
         if not RNS.Transport.has_path(dest_hash):
             RNS.Transport.request_path(dest_hash)
@@ -41,9 +87,11 @@ class LXMFClient:
                 if RNS.Transport.has_path(dest_hash):
                     break
                 await asyncio.sleep(0.1)
-        dest_identity = RNS.Identity.recall(dest_hash) or RNS.Identity.recall(dest_hash, create=True)
+        dest_identity = RNS.Identity.recall(dest_hash) or RNS.Identity.recall(
+            dest_hash, create=True
+        )
         if payload_obj is None:
-            content_bytes = b''
+            content_bytes = b""
         elif isinstance(payload_obj, bytes):
             content_bytes = payload_obj
         else:
@@ -51,26 +99,37 @@ class LXMFClient:
             if self.auth_token:
                 import json
                 import zlib
+
                 obj = dataclass_from_json(type(payload_obj), data)
                 obj_dict = obj.__dict__
-                obj_dict['auth_token'] = self.auth_token
-                data = zlib.compress(json.dumps(obj_dict).encode('utf-8'))
+                obj_dict["auth_token"] = self.auth_token
+                data = zlib.compress(json.dumps(obj_dict).encode("utf-8"))
             content_bytes = data
+        request_id = uuid.uuid4().hex
         lxmsg = LXMF.LXMessage(
-            RNS.Destination(dest_identity, RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"),
-            self.source_identity, content_bytes, command
+            RNS.Destination(
+                dest_identity,
+                RNS.Destination.OUT,
+                RNS.Destination.SINGLE,
+                "lxmf",
+                "delivery",
+            ),
+            self.source_identity,
+            content_bytes,
+            command,
+            fields={"request_id": request_id},
         )
+        lxmsg.pack()
         future = None
         if await_response:
-            response_title = response_title or f"{command}_response"
             future = self._loop.create_future()
-            self._futures[response_title] = future
+            self._futures[request_id] = future
         self.router.handle_outbound(lxmsg)
         if future:
             try:
                 resp = await asyncio.wait_for(future, timeout=self.timeout)
                 return resp
             except asyncio.TimeoutError:
-                self._futures.pop(response_title, None)
+                self._futures.pop(request_id, None)
                 raise TimeoutError("No response received")
         return None


### PR DESCRIPTION
## Summary
- generate a UUID `request_id` for each command and embed it in LXMF message fields for response correlation
- resolve futures keyed by that `request_id` instead of the message hash
- update client tests to use the new request identifier

## Testing
- `flake8 reticulum_openapi/client.py tests/test_client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689526f15e608325a1a52171ca11a741