### PR TITLE
Validate MessagePack int64 bounds

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -4,4 +4,5 @@
 - [x] Fix flake8 errors across the codebase.
 - [x] Add loopback link tests for client requests and resource transfer.
 - [x] Update generator docs to use Python tooling and note post-generation tweaks.
+- [x] Add integer range checks for MessagePack encoding.
 

--- a/reticulum_openapi/codec_msgpack.py
+++ b/reticulum_openapi/codec_msgpack.py
@@ -80,6 +80,8 @@ def _pack_int(n: int) -> bytes:
             return b"\xd1" + (n & 0xFFFF).to_bytes(2, "big")
         if -2147483648 <= n <= 2147483647:
             return b"\xd2" + (n & 0xFFFFFFFF).to_bytes(4, "big")
+        if n < -(2**63) or n > 2**64 - 1:
+            raise CodecError("Integer out of range for MessagePack")
         return b"\xd3" + (n & 0xFFFFFFFFFFFFFFFF).to_bytes(8, "big")
     else:
         # unsigned
@@ -89,6 +91,8 @@ def _pack_int(n: int) -> bytes:
             return b"\xcd" + n.to_bytes(2, "big")
         if n <= 0xFFFFFFFF:
             return b"\xce" + n.to_bytes(4, "big")
+        if n < -(2**63) or n > 2**64 - 1:
+            raise CodecError("Integer out of range for MessagePack")
         return b"\xcf" + n.to_bytes(8, "big")
 
 

--- a/tests/test_codec_msgpack.py
+++ b/tests/test_codec_msgpack.py
@@ -14,6 +14,20 @@ def test_basic_integers():
     assert b == b"\xff"
 
 
+def test_int64_bounds_and_overflow():
+    """Check 64-bit integer boundaries and overflow handling."""
+    min_signed = -(2**63)
+    max_unsigned = 2**64 - 1
+    b = codec.to_canonical_bytes(min_signed)
+    assert b == b"\xd3" + (min_signed & 0xFFFFFFFFFFFFFFFF).to_bytes(8, "big")
+    b = codec.to_canonical_bytes(max_unsigned)
+    assert b == b"\xcf" + max_unsigned.to_bytes(8, "big")
+    with pytest.raises(codec.CodecError):
+        codec.to_canonical_bytes(min_signed - 1)
+    with pytest.raises(codec.CodecError):
+        codec.to_canonical_bytes(max_unsigned + 1)
+
+
 def test_basic_strings_and_bins():
     """Ensure strings and binary data are encoded correctly."""
     b = codec.to_canonical_bytes("a")


### PR DESCRIPTION
## Summary
- ensure `_pack_int` raises `CodecError` when integers fall outside MessagePack's 64-bit range
- test 64-bit boundary values and overflow cases
- record task completion for range checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a08d233788325a38106679ac4e976