### PR TITLE
Fix flake8 issues and improve LXMF service error handling

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -23,3 +23,7 @@
 - [x] Resolve merge artifacts in service tests.
 
 
+## 2025-08-12
+- [x] Resolve flake8 errors in services, models, and tests.
+
+

--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -83,7 +83,7 @@ class LXMFClient:
             )
             if self.auth_token:
                 data_dict["auth_token"] = self.auth_token
-              try:
+            try:
                 content_bytes = dataclass_to_msgpack(data_dict)
             except Exception:
                 content_bytes = dataclass_to_json(data_dict)

--- a/reticulum_openapi/link_client.py
+++ b/reticulum_openapi/link_client.py
@@ -178,7 +178,6 @@ class LinkClient:
             except Exception:
                 payload = dataclass_to_json(data)
 
-
         fut: asyncio.Future[bytes] = self._loop.create_future()
 
         def resp_cb(receipt: Any) -> None:

--- a/reticulum_openapi/model.py
+++ b/reticulum_openapi/model.py
@@ -3,6 +3,8 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import fields
 from dataclasses import is_dataclass
+import json
+import zlib
 from typing import List
 from typing import Optional
 from typing import Type
@@ -23,8 +25,6 @@ __all__ = [
     "dataclass_from_msgpack",
     "dataclass_to_json",
     "dataclass_from_json",
-    "dataclass_to_msgpack",
-    "dataclass_from_msgpack",
     "BaseModel",
     "create_async_engine",
     "async_sessionmaker",
@@ -120,11 +120,6 @@ def dataclass_from_msgpack(cls: Type[T], data: bytes) -> T:
     """
     obj_dict = msgpack_from_bytes(data)
     return _construct(cls, obj_dict)
-
-
-def dataclass_from_json(cls: Type[T], data: bytes) -> T:
-    """Deprecated wrapper for :func:`dataclass_from_msgpack`."""
-    return dataclass_from_msgpack(cls, data)
 
 
 @dataclass

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -1,6 +1,7 @@
 # reticulum_openapi/service.py
 import asyncio
-import msgpack
+import json
+import zlib
 import RNS
 import LXMF
 from typing import Callable
@@ -137,15 +138,16 @@ class LXMFService:
             else:
                 try:
                     payload_obj = msgpack_from_bytes(payload_bytes)
-                except Exception:
+                except Exception as e:
+                    RNS.log(f"Invalid MessagePack payload for {cmd}: {e}")
                     try:
                         json_bytes = zlib.decompress(payload_bytes)
                         payload_obj = json.loads(json_bytes.decode("utf-8"))
                     except (zlib.error, json.JSONDecodeError):
                         try:
                             payload_obj = json.loads(payload_bytes.decode("utf-8"))
-                        except Exception as e:
-                            RNS.log(f"Invalid JSON payload for {cmd}: {e}")
+                        except Exception as json_exc:
+                            RNS.log(f"Invalid JSON payload for {cmd}: {json_exc}")
                             return
             if payload_schema is not None:
                 try:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,6 @@
 import asyncio
 from dataclasses import dataclass
 from types import SimpleNamespace
-import msgpack
 import pytest
 
 from reticulum_openapi import client as client_module
@@ -135,7 +134,9 @@ async def test_send_command_includes_token(monkeypatch):
         captured["pre"] = obj
         return original_dc_to_msgpack(obj)
 
-    monkeypatch.setattr(client_module, "dataclass_to_msgpack", fake_dataclass_to_msgpack)
+    monkeypatch.setattr(
+        client_module, "dataclass_to_msgpack", fake_dataclass_to_msgpack
+    )
 
     await cli.send_command("aa", "CMD", Sample(text="hello"), await_response=False)
 

--- a/tests/test_client_extra.py
+++ b/tests/test_client_extra.py
@@ -1,7 +1,5 @@
 import asyncio
 from types import SimpleNamespace
-
-import msgpack
 import pytest
 
 from reticulum_openapi import client as client_module
@@ -138,7 +136,10 @@ async def test_send_command_dict_payload(monkeypatch):
     def fake_dataclass_to_msgpack(obj):
         captured["obj"] = obj
         return original(obj)
-    monkeypatch.setattr(client_module, "dataclass_to_msgpack", fake_dataclass_to_msgpack)
+
+    monkeypatch.setattr(
+        client_module, "dataclass_to_msgpack", fake_dataclass_to_msgpack
+    )
 
     await cli.send_command("aa", "CMD", {"x": 1}, await_response=False)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,11 +1,15 @@
 from dataclasses import dataclass
 
 from reticulum_openapi.model import (
-    dataclass_from_json,
+    BaseModel,
     dataclass_from_msgpack,
-    dataclass_to_json,
-    dataclass_to_msgpack
+    dataclass_to_msgpack,
 )
+from typing import List, Union
+from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+import pytest
 
 
 @dataclass

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,14 +3,11 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import Mock
 
-import msgpack
 import pytest
 
-from reticulum_openapi.model import dataclass_to_msgpack
 from reticulum_openapi.service import LXMFService
 from reticulum_openapi.model import dataclass_to_msgpack
 from reticulum_openapi.codec_msgpack import from_bytes as msgpack_from_bytes
-
 
 
 @dataclass
@@ -73,7 +70,6 @@ async def test_lxmf_callback_schema_validation():
     valid_msg = SimpleNamespace(
         title="SCHEMA",
         content=dataclass_to_msgpack({"num": 5}),
-
         source=None,
     )
     service._lxmf_delivery_callback(valid_msg)
@@ -84,7 +80,6 @@ async def test_lxmf_callback_schema_validation():
     invalid_msg = SimpleNamespace(
         title="SCHEMA",
         content=dataclass_to_msgpack({"num": "bad"}),
-
         source=None,
     )
     service._lxmf_delivery_callback(invalid_msg)
@@ -120,7 +115,6 @@ async def test_lxmf_callback_dispatches_response():
     assert dest is src
     assert title == "PING_response"
     assert msgpack_from_bytes(payload_bytes) == {"status": "ok"}
-
 
 
 def test_get_api_specification_returns_registered_routes():

--- a/tests/test_service_extra.py
+++ b/tests/test_service_extra.py
@@ -1,11 +1,11 @@
-
-import zlib
+import asyncio
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+
 from reticulum_openapi import service as service_module
-from dataclasses import dataclass
 from reticulum_openapi.model import dataclass_to_msgpack
 
 


### PR DESCRIPTION
## Summary
- fix incorrect indentation and ensure LXMFClient serializes payloads with MsgPack fallback to JSON
- add missing imports and remove duplicate definitions in model and service modules
- clean up tests to satisfy flake8 and log invalid MessagePack payloads

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b38ce4b5c8325a2e842e5528c6ed1