### PR TITLE
Use configurable timeout for LXMF path discovery

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -27,3 +27,7 @@
 - [x] Resolve flake8 errors in services, models, and tests.
 
 
+## 2025-09-16
+- [x] Align LXMF client path discovery with configurable timeouts and cover success/timeout cases in tests.
+
+


### PR DESCRIPTION
## Summary
- allow `LXMFClient.send_command` to respect the configurable timeout during path discovery and raise a clear error when a path is unavailable
- extend client tests to cover successful path discovery and timeout scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c93255a13883259fa3365cf54a70af