### PR TITLE
Persist Reticulum identities across restarts

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -31,3 +31,7 @@
 - [x] Align LXMF client path discovery with configurable timeouts and cover success/timeout cases in tests.
 
 
+## 2025-09-17
+- [x] Persist and reuse Reticulum identities for services and clients when available in configuration.
+
+

--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -5,6 +5,7 @@ from dataclasses import asdict
 from dataclasses import is_dataclass
 from typing import Optional
 from typing import Dict
+from .identity import load_or_create_identity
 from .model import dataclass_to_json
 from .model import dataclass_to_msgpack
 
@@ -26,7 +27,7 @@ class LXMFClient:
         self.router = LXMF.LXMRouter(storagepath=storage_path)
         self.router.register_delivery_callback(self._callback)
         if identity is None:
-            identity = RNS.Identity()
+            identity = load_or_create_identity(config_path)
         self.identity = identity
         self.source_identity = self.router.register_delivery_identity(
             identity, display_name=display_name, stamp_cost=0
@@ -73,7 +74,9 @@ class LXMFClient:
 
         if not RNS.Transport.has_path(dest_hash):
             RNS.Transport.request_path(dest_hash)
-            deadline = None if path_timeout is None else self._loop.time() + path_timeout
+            deadline = (
+                None if path_timeout is None else self._loop.time() + path_timeout
+            )
             while not RNS.Transport.has_path(dest_hash):
                 if deadline is not None and self._loop.time() >= deadline:
                     raise TimeoutError(

--- a/reticulum_openapi/identity.py
+++ b/reticulum_openapi/identity.py
@@ -1,0 +1,85 @@
+"""Utilities for loading persistent Reticulum identities."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import RNS
+
+
+def _resolve_config_directory(config_path: Optional[str]) -> Optional[str]:
+    """Determine the configuration directory that should contain the identity file.
+
+    Args:
+        config_path (Optional[str]): Explicit configuration directory or file path.
+
+    Returns:
+        Optional[str]: Directory path expected to hold the ``identity`` file.
+    """
+    candidates = []
+    if config_path:
+        expanded = os.path.abspath(os.path.expanduser(config_path))
+        candidates.append(expanded)
+        parent = os.path.dirname(expanded)
+        if parent and parent != expanded:
+            candidates.append(parent)
+    reticulum_dir = getattr(RNS.Reticulum, "configdir", None)
+    if reticulum_dir:
+        candidates.append(os.path.abspath(os.path.expanduser(reticulum_dir)))
+    ordered = []
+    seen = set()
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        ordered.append(candidate)
+    for candidate in ordered:
+        if os.path.isdir(candidate):
+            return candidate
+    return ordered[0] if ordered else None
+
+
+def load_or_create_identity(config_path: Optional[str] = None) -> RNS.Identity:
+    """Load or create the Reticulum identity located in the configuration directory.
+
+    Args:
+        config_path (Optional[str]): Explicit configuration directory or config file
+            path. Defaults to ``None`` to rely on ``RNS.Reticulum.configdir``.
+
+    Returns:
+        RNS.Identity: The loaded or newly created identity instance.
+    """
+    config_dir = _resolve_config_directory(config_path)
+    identity_path = os.path.join(config_dir, "identity") if config_dir else None
+    identity = None
+    loader = getattr(RNS.Identity, "from_file", None)
+    if identity_path and callable(loader) and os.path.isfile(identity_path):
+        try:
+            identity = loader(identity_path)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            RNS.log(
+                f"Failed to load Reticulum identity from {identity_path}: {exc}",
+                RNS.LOG_WARNING,
+            )
+            identity = None
+        if identity is None:
+            RNS.log(
+                f"Stored Reticulum identity at {identity_path} was invalid; generating a new one.",
+                RNS.LOG_WARNING,
+            )
+    if identity is not None:
+        return identity
+    identity = RNS.Identity()
+    if identity_path and hasattr(identity, "to_file"):
+        directory = os.path.dirname(identity_path)
+        try:
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            identity.to_file(identity_path)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            RNS.log(
+                f"Could not persist Reticulum identity to {identity_path}: {exc}",
+                RNS.LOG_WARNING,
+            )
+    return identity

--- a/reticulum_openapi/link_client.py
+++ b/reticulum_openapi/link_client.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import RNS
 
+from .identity import load_or_create_identity
 from .model import dataclass_to_json
 from .model import dataclass_to_msgpack
 
@@ -86,7 +87,9 @@ class LinkClient:
             identity (RNS.Identity, optional): Local identity. Defaults to a new identity.
         """
         self.reticulum = RNS.Reticulum(config_path)
-        self.identity = identity or RNS.Identity()
+        if identity is None:
+            identity = load_or_create_identity(config_path)
+        self.identity = identity
         self._loop = asyncio.get_event_loop()
         self.established: asyncio.Event = asyncio.Event()
         self.closed: asyncio.Event = asyncio.Event()

--- a/reticulum_openapi/link_service.py
+++ b/reticulum_openapi/link_service.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 import RNS
 
+from .identity import load_or_create_identity
+
 
 class LinkResourceService:
     """Service utilities for receiving resources on a link."""
@@ -84,7 +86,9 @@ class LinkService:
                 transmissions.
         """
         self.reticulum = RNS.Reticulum(config_path)
-        self.identity = identity or RNS.Identity()
+        if identity is None:
+            identity = load_or_create_identity(config_path)
+        self.identity = identity
         self._loop = asyncio.get_event_loop()
         self.destination = RNS.Destination(
             self.identity,

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -13,6 +13,7 @@ from dataclasses import is_dataclass
 from jsonschema import validate
 from jsonschema import ValidationError
 from .codec_msgpack import from_bytes as msgpack_from_bytes
+from .identity import load_or_create_identity
 from .model import dataclass_from_json
 from .model import dataclass_from_msgpack
 from .model import dataclass_to_json
@@ -51,7 +52,8 @@ class LXMFService:
         self.router.register_delivery_callback(self._lxmf_delivery_callback)
         # Set up identity and destination for this service
         if identity is None:
-            identity = RNS.Identity()  # generate a new random identity (keypair)
+            identity = load_or_create_identity(config_path)
+        self.identity = identity
         # Register identity with LXMF for message delivery
         self.source_identity = self.router.register_delivery_identity(
             identity, display_name=display_name, stamp_cost=stamp_cost

--- a/tests/test_client_extra.py
+++ b/tests/test_client_extra.py
@@ -43,6 +43,11 @@ async def test_client_init(monkeypatch):
     monkeypatch.setattr(client_module.RNS, "Destination", DummyDestination)
     monkeypatch.setattr(client_module.LXMF, "LXMRouter", DummyRouter)
     monkeypatch.setattr(client_module.LXMF, "LXMessage", object)
+    monkeypatch.setattr(
+        client_module,
+        "load_or_create_identity",
+        lambda *a, **k: DummyIdentity(),
+    )
 
     cli = client_module.LXMFClient()
     assert isinstance(cli.router, DummyRouter)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -39,6 +39,7 @@ async def test_run_business_logic(monkeypatch):
 
     async def logic(a, b):
         return a + b
+
     result = await ctrl.run_business_logic(logic, 2, 3)
     assert result == 5
 
@@ -49,5 +50,6 @@ async def test_run_business_logic_error():
 
     async def logic():
         raise c.APIException("fail", 401)
+
     result = await ctrl.run_business_logic(logic)
     assert result == {"error": "fail", "code": 401}

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,87 @@
+"""Tests for persistent identity loading utilities."""
+
+from pathlib import Path
+
+from reticulum_openapi import identity as identity_module
+
+
+def test_load_identity_reuses_existing_file(monkeypatch, tmp_path):
+    """Existing identity files should be loaded without creating new keys."""
+
+    existing_identity = object()
+
+    class DummyIdentity:
+        created = 0
+        load_calls = 0
+        saved_paths: list[str] = []
+
+        def __init__(self):
+            DummyIdentity.created += 1
+
+        @staticmethod
+        def from_file(path: str):
+            DummyIdentity.load_calls += 1
+            return existing_identity
+
+        def to_file(self, path: str) -> None:
+            DummyIdentity.saved_paths.append(path)
+
+    monkeypatch.setattr(identity_module.RNS, "Identity", DummyIdentity)
+    monkeypatch.setattr(
+        identity_module.RNS.Reticulum,
+        "configdir",
+        str(tmp_path),
+    )
+    identity_file = tmp_path / "identity"
+    identity_file.write_text("stub")
+
+    result = identity_module.load_or_create_identity()
+
+    assert result is existing_identity
+    assert DummyIdentity.created == 0
+    assert DummyIdentity.load_calls == 1
+    assert DummyIdentity.saved_paths == []
+
+
+def test_load_identity_creates_when_missing(monkeypatch, tmp_path):
+    """A new identity is created and persisted when no file exists."""
+
+    class DummyIdentity:
+        created = 0
+        load_calls = 0
+        saved_paths: list[str] = []
+        persisted_instance = None
+
+        def __init__(self):
+            DummyIdentity.created += 1
+            DummyIdentity.persisted_instance = self
+
+        @staticmethod
+        def from_file(path: str):
+            DummyIdentity.load_calls += 1
+            if Path(path).exists():
+                return DummyIdentity.persisted_instance
+            return None
+
+        def to_file(self, path: str) -> None:
+            DummyIdentity.saved_paths.append(path)
+            Path(path).write_text("saved")
+
+    monkeypatch.setattr(identity_module.RNS, "Identity", DummyIdentity)
+    monkeypatch.setattr(
+        identity_module.RNS.Reticulum,
+        "configdir",
+        str(tmp_path),
+    )
+
+    created = identity_module.load_or_create_identity()
+
+    assert isinstance(created, DummyIdentity)
+    assert DummyIdentity.created == 1
+    assert DummyIdentity.saved_paths == [str(tmp_path / "identity")]
+
+    loaded = identity_module.load_or_create_identity()
+
+    assert loaded is created
+    assert DummyIdentity.load_calls == 1
+    assert DummyIdentity.created == 1

--- a/tests/test_link_client.py
+++ b/tests/test_link_client.py
@@ -73,6 +73,11 @@ async def test_send_serializes_dict(monkeypatch):
     monkeypatch.setattr(lc_module.RNS, "Identity", FakeIdentity)
     monkeypatch.setattr(lc_module.RNS, "Destination", FakeDestination)
     monkeypatch.setattr(lc_module.RNS, "Link", FakeLink)
+    monkeypatch.setattr(
+        lc_module,
+        "load_or_create_identity",
+        lambda *a, **k: FakeIdentity(),
+    )
 
     captured = {}
 
@@ -95,6 +100,11 @@ async def test_request_returns_response(monkeypatch):
     monkeypatch.setattr(lc_module.RNS, "Identity", FakeIdentity)
     monkeypatch.setattr(lc_module.RNS, "Destination", FakeDestination)
     monkeypatch.setattr(lc_module.RNS, "Link", FakeLink)
+    monkeypatch.setattr(
+        lc_module,
+        "load_or_create_identity",
+        lambda *a, **k: FakeIdentity(),
+    )
 
     cli = lc_module.LinkClient("aa")
     task = asyncio.create_task(cli.request("/path", {"a": 1}))
@@ -111,6 +121,11 @@ async def test_identify_calls_link(monkeypatch):
     monkeypatch.setattr(lc_module.RNS, "Identity", FakeIdentity)
     monkeypatch.setattr(lc_module.RNS, "Destination", FakeDestination)
     monkeypatch.setattr(lc_module.RNS, "Link", FakeLink)
+    monkeypatch.setattr(
+        lc_module,
+        "load_or_create_identity",
+        lambda *a, **k: FakeIdentity(),
+    )
 
     cli = lc_module.LinkClient("aa")
     ident = FakeIdentity()
@@ -243,6 +258,11 @@ async def test_loopback_request_receives_response(monkeypatch):
         monkeypatch.setattr(module.RNS, "Identity", LoopbackIdentity)
         monkeypatch.setattr(module.RNS, "Destination", LoopbackDestination)
         monkeypatch.setattr(module.RNS, "Link", LoopbackLink)
+        monkeypatch.setattr(
+            module,
+            "load_or_create_identity",
+            lambda *a, **k: LoopbackIdentity(),
+        )
 
     handler_called = asyncio.Event()
 
@@ -272,6 +292,11 @@ async def test_loopback_send_resource(monkeypatch, tmp_path):
         monkeypatch.setattr(module.RNS, "Identity", LoopbackIdentity)
         monkeypatch.setattr(module.RNS, "Destination", LoopbackDestination)
         monkeypatch.setattr(module.RNS, "Link", LoopbackLink)
+        monkeypatch.setattr(
+            module,
+            "load_or_create_identity",
+            lambda *a, **k: LoopbackIdentity(),
+        )
     monkeypatch.setattr(lc_module.RNS, "Resource", FakeResource)
 
     storage = tmp_path / "store"

--- a/tests/test_link_service.py
+++ b/tests/test_link_service.py
@@ -48,6 +48,11 @@ async def test_service_accepts_links_and_keepalive(monkeypatch):
     monkeypatch.setattr(ls_module.RNS, "Reticulum", lambda *_: object())
     monkeypatch.setattr(ls_module.RNS, "Identity", FakeIdentity)
     monkeypatch.setattr(ls_module.RNS, "Destination", FakeDestination)
+    monkeypatch.setattr(
+        ls_module,
+        "load_or_create_identity",
+        lambda *a, **k: FakeIdentity(),
+    )
 
     handler_called = asyncio.Event()
 
@@ -71,6 +76,11 @@ async def test_service_stop_closes_links(monkeypatch):
     monkeypatch.setattr(ls_module.RNS, "Reticulum", lambda *_: object())
     monkeypatch.setattr(ls_module.RNS, "Identity", FakeIdentity)
     monkeypatch.setattr(ls_module.RNS, "Destination", FakeDestination)
+    monkeypatch.setattr(
+        ls_module,
+        "load_or_create_identity",
+        lambda *a, **k: FakeIdentity(),
+    )
 
     service = ls_module.LinkService(keepalive_interval=0.1)
     link = FakeLink()
@@ -192,6 +202,11 @@ async def test_loopback_link_established(monkeypatch):
         monkeypatch.setattr(module.RNS, "Identity", LoopbackIdentity)
         monkeypatch.setattr(module.RNS, "Destination", LoopbackDestination)
         monkeypatch.setattr(module.RNS, "Link", LoopbackLink)
+        monkeypatch.setattr(
+            module,
+            "load_or_create_identity",
+            lambda *a, **k: LoopbackIdentity(),
+        )
 
     handler_called = asyncio.Event()
 

--- a/tests/test_service_extra.py
+++ b/tests/test_service_extra.py
@@ -181,6 +181,11 @@ async def test_init_and_add_route(monkeypatch):
 
     monkeypatch.setattr(service_module, "RNS", FakeRNS)
     monkeypatch.setattr(service_module, "LXMF", FakeLXMF)
+    monkeypatch.setattr(
+        service_module,
+        "load_or_create_identity",
+        lambda *a, **k: FakeIdentity(),
+    )
     svc = service_module.LXMFService()
     assert isinstance(svc.router, FakeLXMRouter)
     svc.add_route("PING", lambda: None)


### PR DESCRIPTION
## Summary
- add a shared utility that loads Reticulum identities from the standard configuration directory and persists them when missing
- update LXMF and link clients/services to reuse the persisted identity instead of generating a new one on every start
- extend the test suite with identity loader coverage and patch existing link/client tests to mock the new helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c969d2efc883259639202ce620cec8