### PR TITLE
Add centralized logging configuration

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -16,7 +16,7 @@
 - [x] Update codec Msgpack test to import from reticulum_openapi.
 - [x] Introduce MessagePack utilities and refactor service/client to use them by default.
 - [ ] Evaluate separating compression from JSON serialization helpers.
-- [ ] Introduce centralised logging configuration for services and clients.
+- [x] Introduce centralised logging configuration for services and clients.
 
 - [x] Use MessagePack for dataclass serialization and drop zlib compression.
 - [x] Rename serialization helpers to dataclass_to_msgpack/from_msgpack for clarity.

--- a/reticulum_openapi/controller.py
+++ b/reticulum_openapi/controller.py
@@ -1,17 +1,11 @@
 import logging
-from typing import Any, Callable, Coroutine, TypeVar
 from functools import wraps
+from typing import Any, Callable, Coroutine, TypeVar
 
-# pretty sure every import of this class will trigger a new addHandler event which will result
-# in as many duplicate handlers for the controller logger as there are imports.
-# Setup module logger
-logger = logging.getLogger("reticulum_openapi.controller")
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
-handler.setFormatter(formatter)
-if not logger.handlers:
-    logger.addHandler(handler)
+from .logging import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 
 class APIException(Exception):

--- a/reticulum_openapi/link_service.py
+++ b/reticulum_openapi/link_service.py
@@ -1,6 +1,7 @@
 """Helpers for handling incoming resources on Reticulum links."""
 
 import asyncio
+import logging
 import os
 import shutil
 
@@ -11,6 +12,12 @@ from typing import Dict
 from typing import Optional
 
 import RNS
+
+from .logging import configure_logging
+
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 
 class LinkResourceService:
@@ -59,7 +66,7 @@ class LinkResourceService:
             if self.on_download_complete:
                 self.on_download_complete(dest_path)
         except Exception as exc:
-            RNS.log(f"Failed to store resource: {exc}")
+            logger.exception("Failed to store resource: %s", exc)
 
 
 class LinkService:

--- a/reticulum_openapi/logging.py
+++ b/reticulum_openapi/logging.py
@@ -1,0 +1,45 @@
+"""Shared logging configuration for the ``reticulum_openapi`` package."""
+
+from __future__ import annotations
+
+import logging as _logging
+from typing import Iterable
+
+PACKAGE_LOGGER_NAME = "reticulum_openapi"
+_DEFAULT_LOG_LEVEL = _logging.INFO
+_HANDLER_NAME = "reticulum_openapi.stream"
+_LOG_FORMAT = "[%(asctime)s] %(levelname)s %(name)s: %(message)s"
+
+
+def _handler_exists(handlers: Iterable[_logging.Handler]) -> bool:
+    """Return ``True`` when the shared stream handler has already been added."""
+    for handler in handlers:
+        if getattr(handler, "name", "") == _HANDLER_NAME:
+            return True
+    return False
+
+
+def configure_logging(level: int = _DEFAULT_LOG_LEVEL) -> _logging.Logger:
+    """Configure and return the package logger.
+
+    Args:
+        level (int): Logging level applied to the package logger. Defaults to
+            :data:`logging.INFO`.
+
+    Returns:
+        logging.Logger: The shared package logger instance.
+    """
+    logger = _logging.getLogger(PACKAGE_LOGGER_NAME)
+    logger.setLevel(level)
+    if not _handler_exists(logger.handlers):
+        handler = _logging.StreamHandler()
+        handler.set_name(_HANDLER_NAME)
+        handler.setFormatter(_logging.Formatter(_LOG_FORMAT))
+        logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+configure_logging()
+
+__all__ = ["configure_logging", "PACKAGE_LOGGER_NAME"]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -51,3 +51,9 @@ async def test_run_business_logic_error():
         raise c.APIException("fail", 401)
     result = await ctrl.run_business_logic(logic)
     assert result == {"error": "fail", "code": 401}
+
+
+def test_controller_logger_uses_shared_configuration():
+    ctrl = c.Controller()
+    assert ctrl.logger is c.logger
+    assert ctrl.logger.name == "reticulum_openapi.controller"

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,55 @@
+"""Tests for shared logging configuration."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import List
+
+import reticulum_openapi.logging as logging_config
+
+
+def _reset_package_logger() -> None:
+    """Remove all handlers from the package logger to create a clean slate."""
+    package_logger = logging.getLogger(logging_config.PACKAGE_LOGGER_NAME)
+    for handler in list(package_logger.handlers):
+        package_logger.removeHandler(handler)
+        handler.close()
+    package_logger.propagate = True
+
+
+def _handler_ids(logger: logging.Logger) -> List[int]:
+    """Return stable identifiers for handlers attached to ``logger``."""
+    return [id(handler) for handler in logger.handlers]
+
+
+def test_configure_logging_is_idempotent() -> None:
+    """Importing or configuring logging repeatedly must not add handlers."""
+    _reset_package_logger()
+    reloaded_logging = importlib.reload(logging_config)
+    package_logger = logging.getLogger(reloaded_logging.PACKAGE_LOGGER_NAME)
+    assert len(package_logger.handlers) == 1
+    existing_handlers = _handler_ids(package_logger)
+
+    reloaded_logging.configure_logging()
+    reloaded_logging.configure_logging()
+
+    assert _handler_ids(package_logger) == existing_handlers
+
+
+def test_controller_import_does_not_duplicate_handlers() -> None:
+    """Reloading controller reuses the shared logger configuration."""
+    _reset_package_logger()
+    reloaded_logging = importlib.reload(logging_config)
+    package_logger = logging.getLogger(reloaded_logging.PACKAGE_LOGGER_NAME)
+    assert len(package_logger.handlers) == 1
+    initial_handlers = _handler_ids(package_logger)
+
+    import reticulum_openapi.controller as controller_module
+
+    controller = importlib.reload(controller_module)
+    assert _handler_ids(package_logger) == initial_handlers
+
+    controller = importlib.reload(controller)
+    assert _handler_ids(package_logger) == initial_handlers
+    assert controller.logger is logging.getLogger(controller.__name__)


### PR DESCRIPTION
## Summary
- add a shared logging configuration module for the package
- update controllers and services to use the centralized logging setup
- add tests ensuring the logger configuration is reused without duplicate handlers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96a01ee4883259044427726efe298