### PR TITLE
Fix lint errors and syntax issue

### DIFF
--- a/examples/EmergencyManagement/Server/server_emergency.py
+++ b/examples/EmergencyManagement/Server/server_emergency.py
@@ -1,3 +1,7 @@
+"""Run the emergency management server example."""
+
+import asyncio
+from pathlib import Path
 import sys
 
 
@@ -41,21 +45,23 @@ def _ensure_standard_library_on_path() -> None:
                     sys.path.append(candidate)
 
 
-_ensure_standard_library_on_path()
+def _ensure_project_root_on_path() -> None:
+    """Ensure the repository root is importable when run as a script."""
 
-import asyncio
-from pathlib import Path
+    # Reason: Allow running the server example from its directory by ensuring
+    # project-level imports resolve when executed as a script.
+    if __package__ is None or __package__ == "":
+        project_root = Path(__file__).resolve().parents[3]
+        project_root_str = str(project_root)
+        if project_root_str not in sys.path:
+            sys.path.insert(0, project_root_str)
 
-# Reason: Allow running the server example from its directory by ensuring
-# project-level imports resolve when executed as a script.
-if __package__ is None or __package__ == "":
-    project_root = Path(__file__).resolve().parents[3]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
 
-from examples.EmergencyManagement.Server.service_emergency import EmergencyService
-from examples.EmergencyManagement.Server.database import init_db
+def _configure_environment() -> None:
+    """Prepare import paths required for the example service."""
+
+    _ensure_standard_library_on_path()
+    _ensure_project_root_on_path()
 
 
 async def main() -> None:
@@ -65,6 +71,10 @@ async def main() -> None:
         None: The coroutine completes after announcing the service and
         idling for a brief period.
     """
+
+    _configure_environment()
+    from examples.EmergencyManagement.Server.database import init_db
+    from examples.EmergencyManagement.Server.service_emergency import EmergencyService
 
     await init_db()
     async with EmergencyService() as svc:

--- a/reticulum_openapi/link_service.py
+++ b/reticulum_openapi/link_service.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import os
 import shutil
-
 from typing import Any
 from typing import Awaitable
 from typing import Callable
@@ -13,14 +12,11 @@ from typing import Optional
 
 import RNS
 
-
+from .identity import load_or_create_identity
 from .logging import configure_logging
 
 configure_logging()
 logger = logging.getLogger(__name__)
-
-from .identity import load_or_create_identity
-
 
 
 class LinkResourceService:

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -103,7 +103,6 @@ class LXMFService:
         self._routes[normalised_command] = (handler, payload_type, payload_schema)
         RNS.log(f"Route registered: '{normalised_command}' -> {handler}")
 
-
     def get_api_specification(self) -> dict:
         """Return a minimal JSON specification of available commands."""
         commands = {}
@@ -147,17 +146,18 @@ class LXMFService:
             logger.exception("Error reading incoming message: %s", exc)
             return  # Exit if message is malformed
 
-        logger.info(
-            "Received LXMF message - Title: '%s', Size: %d bytes",
-            cmd,
-            len(payload_bytes) if payload_bytes else 0,
-
         cmd = self._normalise_command_title(raw_title)
         if cmd is None:
             RNS.log(f"Invalid command title received: {raw_title!r}")
             return
+        payload_length = len(payload_bytes) if payload_bytes else 0
+        logger.info(
+            "Received LXMF message - Title: '%s', Size: %d bytes",
+            cmd,
+            payload_length,
+        )
         RNS.log(
-            f"Received LXMF message - Title: '{cmd}', Size: {len(payload_bytes) if payload_bytes else 0} bytes"
+            f"Received LXMF message - Title: '{cmd}', Size: {payload_length} bytes"
         )
         # Look up the handler for the command
         if cmd not in self._routes:


### PR DESCRIPTION
## Summary
- delay runtime imports in the emergency server example until after environment setup so module-level imports satisfy flake8
- reorder link service imports around logging configuration to keep module-level code PEP 8 compliant
- fix the LXMF service delivery logging block to avoid syntax errors while preserving diagnostics

## Testing
- flake8 . --exclude venv_linux

------
https://chatgpt.com/codex/tasks/task_e_68cae1c656c88325bb1c9b942ba4a647