### PR TITLE
Handle dataclass auth tokens in LXMF callback

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -36,5 +36,6 @@
 
 ## 2025-09-17
 - [x] Persist and reuse Reticulum identities for services and clients when available in configuration.
+- [x] Handle dataclass auth tokens in LXMF service delivery callback and extend tests.
 
 

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -207,10 +207,17 @@ class LXMFService:
                         exc.message,
                     )
                     return
-            if self.auth_token and isinstance(payload_obj, dict):
-                if payload_obj.get("auth_token") != self.auth_token:
-                    logger.warning("Authentication failed for message: %s", cmd)
-                    return
+            if self.auth_token:
+                payload_dict = None
+                if is_dataclass(payload_obj):
+                    payload_dict = asdict(payload_obj)
+                elif isinstance(payload_obj, dict):
+                    payload_dict = payload_obj
+
+                if payload_dict is not None:
+                    if payload_dict.get("auth_token") != self.auth_token:
+                        logger.warning("Authentication failed for message: %s", cmd)
+                        return
         else:
             payload_obj = None  # No payload content
 


### PR DESCRIPTION
## Summary
- convert dataclass LXMF payloads to dictionaries before verifying authentication tokens
- extend service tests with dataclass token acceptance and rejection cases
- note the completed auth-token handling task in TASK.md

## Testing
- pytest tests/test_service.py

------
https://chatgpt.com/codex/tasks/task_e_68cb302c48e48325998e72850e39d0be