### PR TITLE
Split JSON serialization and add compression helper

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -15,7 +15,7 @@
 
 - [x] Update codec Msgpack test to import from reticulum_openapi.
 - [x] Introduce MessagePack utilities and refactor service/client to use them by default.
-- [ ] Evaluate separating compression from JSON serialization helpers.
+- [x] Evaluate separating compression from JSON serialization helpers.
 - [x] Introduce centralised logging configuration for services and clients.
 
 - [x] Use MessagePack for dataclass serialization and drop zlib compression.

--- a/examples/EmergencyManagement/Server/server_emergency.py
+++ b/examples/EmergencyManagement/Server/server_emergency.py
@@ -64,6 +64,18 @@ def _configure_environment() -> None:
     _ensure_project_root_on_path()
 
 
+_configure_environment()
+
+try:
+    from examples.EmergencyManagement.Server.database import init_db
+    from examples.EmergencyManagement.Server.service_emergency import (
+        EmergencyService,
+    )
+except Exception:  # pragma: no cover - best effort for optional imports
+    init_db = None
+    EmergencyService = None
+
+
 async def main() -> None:
     """Run the emergency management service for a short demonstration.
 
@@ -73,9 +85,6 @@ async def main() -> None:
     """
 
     _configure_environment()
-    from examples.EmergencyManagement.Server.database import init_db
-    from examples.EmergencyManagement.Server.service_emergency import EmergencyService
-
     await init_db()
     async with EmergencyService() as svc:
         svc.announce()

--- a/reticulum_openapi/__init__.py
+++ b/reticulum_openapi/__init__.py
@@ -4,10 +4,11 @@ from .controller import APIException
 from .controller import Controller
 from .controller import handle_exceptions
 from .model import BaseModel
+from .model import compress_json
 from .model import dataclass_from_json
 from .model import dataclass_from_msgpack
 from .model import dataclass_to_json
-
+from .model import dataclass_to_json_bytes
 from .model import dataclass_to_msgpack
 from .link_client import LinkClient
 from .link_service import LinkService
@@ -19,9 +20,11 @@ __all__ = [
     "APIException",
     "handle_exceptions",
     "BaseModel",
+    "compress_json",
     "dataclass_from_json",
     "dataclass_from_msgpack",
     "dataclass_to_json",
+    "dataclass_to_json_bytes",
     "dataclass_to_msgpack",
     "LinkClient",
     "LinkService",

--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -6,7 +6,8 @@ from dataclasses import is_dataclass
 from typing import Optional
 from typing import Dict
 from .identity import load_or_create_identity
-from .model import dataclass_to_json
+from .model import compress_json
+from .model import dataclass_to_json_bytes
 from .model import dataclass_to_msgpack
 
 
@@ -116,7 +117,8 @@ class LXMFClient:
             try:
                 content_bytes = dataclass_to_msgpack(data_dict)
             except Exception:
-                content_bytes = dataclass_to_json(data_dict)
+                json_bytes = dataclass_to_json_bytes(data_dict)
+                content_bytes = compress_json(json_bytes)
 
         lxmsg = LXMF.LXMessage(
             RNS.Destination(

--- a/reticulum_openapi/link_client.py
+++ b/reticulum_openapi/link_client.py
@@ -11,7 +11,8 @@ from typing import Optional
 import RNS
 
 from .identity import load_or_create_identity
-from .model import dataclass_to_json
+from .model import compress_json
+from .model import dataclass_to_json_bytes
 from .model import dataclass_to_msgpack
 
 
@@ -145,7 +146,8 @@ class LinkClient:
             try:
                 payload = dataclass_to_msgpack(data)
             except Exception:
-                payload = dataclass_to_json(data)
+                json_bytes = dataclass_to_json_bytes(data)
+                payload = compress_json(json_bytes)
 
         self.link.send(payload)
 
@@ -176,7 +178,8 @@ class LinkClient:
             try:
                 payload = dataclass_to_msgpack(data)
             except Exception:
-                payload = dataclass_to_json(data)
+                json_bytes = dataclass_to_json_bytes(data)
+                payload = compress_json(json_bytes)
 
         fut: asyncio.Future[bytes] = self._loop.create_future()
 

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -19,9 +19,10 @@ from jsonschema import validate
 from .codec_msgpack import from_bytes as msgpack_from_bytes
 from .logging import configure_logging
 from .identity import load_or_create_identity
+from .model import compress_json
 from .model import dataclass_from_json
 from .model import dataclass_from_msgpack
-from .model import dataclass_to_json
+from .model import dataclass_to_json_bytes
 from .model import dataclass_to_msgpack
 
 
@@ -236,16 +237,16 @@ class LXMFService:
                         resp_bytes = dataclass_to_msgpack(result)
                     except Exception:
                         try:
-                            resp_bytes = dataclass_to_json(result)
+                            json_bytes = dataclass_to_json_bytes(result)
+                            resp_bytes = compress_json(json_bytes)
                         except Exception as exc:
                             logger.exception(
                                 "Failed to serialize result dataclass for %s: %s",
                                 cmd,
                                 exc,
                             )
-                            resp_bytes = zlib.compress(
-                                json.dumps(result).encode("utf-8")
-                            )
+                            fallback_json = json.dumps(result).encode("utf-8")
+                            resp_bytes = compress_json(fallback_json)
                 # Determine response command name (could be something like "<command>_response" or a generic)
                 resp_title = f"{cmd}_response"
                 dest_identity = message.source
@@ -331,7 +332,8 @@ class LXMFService:
             try:
                 content_bytes = dataclass_to_msgpack(payload_obj)
             except Exception:
-                content_bytes = dataclass_to_json(payload_obj)
+                json_bytes = dataclass_to_json_bytes(payload_obj)
+                content_bytes = compress_json(json_bytes)
         # Use internal send helper
         self._send_lxmf(dest_identity, command, content_bytes, propagate=propagate)
 

--- a/tests/test_example_filmology.py
+++ b/tests/test_example_filmology.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from reticulum_openapi.model import dataclass_to_json
+from reticulum_openapi.model import compress_json
+from reticulum_openapi.model import dataclass_to_json_bytes
 from reticulum_openapi.service import LXMFService
 
 from examples.filmology.Server.models_filmology import Movie
@@ -33,7 +34,7 @@ async def test_create_movie_success() -> None:
     payload = {"id": 1, "title": "Test", "auth_token": "secret"}
     message = SimpleNamespace(
         title="CreateMovie",
-        content=dataclass_to_json(payload),
+        content=compress_json(dataclass_to_json_bytes(payload)),
         source=None,
     )
 
@@ -65,7 +66,7 @@ async def test_create_movie_schema_validation() -> None:
     invalid = {"id": "bad", "title": "Test", "auth_token": "secret"}
     message = SimpleNamespace(
         title="CreateMovie",
-        content=dataclass_to_json(invalid),
+        content=dataclass_to_json_bytes(invalid),
         source=None,
     )
 
@@ -96,7 +97,7 @@ async def test_create_movie_auth_failure() -> None:
     payload = {"id": 1, "title": "Test", "auth_token": "wrong"}
     message = SimpleNamespace(
         title="CreateMovie",
-        content=dataclass_to_json(payload),
+        content=compress_json(dataclass_to_json_bytes(payload)),
         source=None,
     )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,10 @@ from dataclasses import dataclass
 
 from reticulum_openapi.model import (
     BaseModel,
+    compress_json,
+    dataclass_from_json,
     dataclass_from_msgpack,
+    dataclass_to_json_bytes,
     dataclass_to_msgpack,
 )
 from typing import List, Union
@@ -28,6 +31,22 @@ def test_serialization_roundtrip():
     data = dataclass_to_msgpack(item)
     obj = dataclass_from_msgpack(Item, data)
     assert obj == item
+
+
+def test_json_roundtrip_without_compression():
+    item = Item(name="foo", value=42)
+    json_bytes = dataclass_to_json_bytes(item)
+    obj = dataclass_from_json(Item, json_bytes)
+    assert obj == item
+
+
+def test_json_roundtrip_with_compression():
+    item = Item(name="bar", value=7)
+    json_bytes = dataclass_to_json_bytes(item)
+    compressed = compress_json(json_bytes)
+    obj = dataclass_from_json(Item, compressed)
+    assert obj == item
+    assert compress_json(json_bytes, enabled=False) == json_bytes
 
 
 def test_list_of_items_roundtrip():


### PR DESCRIPTION
## Summary
- add `dataclass_to_json_bytes` and `compress_json` helpers to the model layer while keeping `dataclass_to_json` as a convenience wrapper
- refactor clients, services, and examples to explicitly compress JSON fallbacks using the new helpers
- extend model and filmology tests to cover compressed and uncompressed JSON payloads and ensure the emergency server script exposes its imports when run via `runpy`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb303c355c8325b0a785a9fda250fd