### PR TITLE
Handle invalid identity input in LXMF client

### DIFF
--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -40,9 +40,13 @@ async def main():
         commsStatus=EAMStatus.Green,
         commsMethod="VOIP",
     )
-    resp = await client.send_command(
-        server_id, "CreateEmergencyActionMessage", eam, await_response=True
-    )
+    try:
+        resp = await client.send_command(
+            server_id, "CreateEmergencyActionMessage", eam, await_response=True
+        )
+    except (TypeError, ValueError) as exc:
+        print(f"Invalid server identity hash: {exc}")
+        return
     # Decode MessagePack bytes into a dataclass for readability
     created_eam = EmergencyActionMessage(**from_bytes(resp))
     print("Create response:", created_eam)

--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -60,6 +60,46 @@ class LXMFClient:
         if future is not None and not future.done():
             future.set_result(message.content)
 
+    @staticmethod
+    def _normalise_destination_hex(dest_hex: str) -> str:
+        """Return a cleaned hexadecimal destination hash string.
+
+        Args:
+            dest_hex (str): Raw destination hash input.
+
+        Returns:
+            str: Lowercase hexadecimal string suitable for ``bytes.fromhex``.
+
+        Raises:
+            TypeError: If ``dest_hex`` is not provided as a string.
+            ValueError: If no hexadecimal characters are supplied.
+        """
+
+        if not isinstance(dest_hex, str):
+            raise TypeError("Destination identity hash must be provided as a string")
+
+        cleaned = dest_hex.strip()
+        if cleaned.startswith("<") and cleaned.endswith(">"):
+            cleaned = cleaned[1:-1]
+        cleaned = cleaned.replace(" ", "")
+
+        if not cleaned:
+            raise ValueError("Destination identity hash cannot be empty")
+
+        try:
+            bytes.fromhex(cleaned)
+        except ValueError as exc:
+            raise ValueError(
+                "Destination identity hash must be a hexadecimal string"
+            ) from exc
+
+        if len(cleaned) % 2 != 0:
+            raise ValueError(
+                "Destination identity hash must contain an even number of characters"
+            )
+
+        return cleaned.lower()
+
     async def send_command(
         self,
         dest_hex: str,
@@ -85,6 +125,7 @@ class LXMFClient:
         Raises:
             TimeoutError: If a transport path cannot be established before ``path_timeout`` elapses.
         """
+        dest_hex = self._normalise_destination_hex(dest_hex)
         dest_hash = bytes.fromhex(dest_hex)
         if path_timeout is None:
             path_timeout = self.timeout

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -33,6 +33,33 @@ configure_logging()
 logger = logging.getLogger(__name__)
 
 
+def _convert_dataclasses_to_primitives(value: Any) -> Any:
+    """Convert dataclasses within the value into primitive containers.
+
+    Args:
+        value (Any): Value potentially containing dataclasses.
+
+    Returns:
+        Any: Value with dataclasses recursively converted to dictionaries.
+    """
+
+    if is_dataclass(value):
+        return {
+            key: _convert_dataclasses_to_primitives(item)
+            for key, item in asdict(value).items()
+        }
+    if isinstance(value, dict):
+        return {
+            key: _convert_dataclasses_to_primitives(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [
+            _convert_dataclasses_to_primitives(item) for item in value
+        ]
+    return value
+
+
 def _normalise_for_msgpack(value: Any) -> Any:
     """Convert values into structures supported by canonical MessagePack encoding.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -237,3 +237,20 @@ async def test_callback_ignores_invalid_byte_titles(monkeypatch):
     assert not future.done()
     assert cli._futures["CMD_response"] is future
     assert messages and "Invalid response title" in messages[0]
+
+
+def test_normalise_destination_hex_accepts_wrapped_brackets():
+    value = client_module.LXMFClient._normalise_destination_hex(
+        "  <A1B2C3D4E5F60708>  "
+    )
+    assert value == "a1b2c3d4e5f60708"
+
+
+def test_normalise_destination_hex_rejects_invalid():
+    with pytest.raises(ValueError):
+        client_module.LXMFClient._normalise_destination_hex("not hex")
+
+
+def test_normalise_destination_hex_requires_string():
+    with pytest.raises(TypeError):
+        client_module.LXMFClient._normalise_destination_hex(123)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- normalise LXMF destination identity strings to tolerate surrounding whitespace or angle brackets
- surface a friendly error message in the EmergencyManagement example when an invalid identity hash is entered
- add a dataclass-to-primitive helper for LXMF service responses and unit tests for destination hash normalisation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2b9e9c8d08325af257b2a439b81fc