### PR TITLE
Handle EmergencyManagement client timeouts

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -54,3 +54,7 @@
 - [x] Keep the EmergencyManagement example service running until interrupted and fix LXMF response serialisation regression.
 
 
+
+## 2025-09-24
+- [x] Handle EmergencyManagement client timeouts gracefully to avoid shutdowns.
+

--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -47,17 +47,24 @@ async def main():
     except (TypeError, ValueError) as exc:
         print(f"Invalid server identity hash: {exc}")
         return
+    except TimeoutError as exc:
+        print(f"Request timed out: {exc}")
+        return
     # Decode MessagePack bytes into a dataclass for readability
     created_eam = EmergencyActionMessage(**from_bytes(resp))
     print("Create response:", created_eam)
 
     # Retrieve the message back from the server to demonstrate persistence
-    retrieved = await client.send_command(
-        server_id,
-        "RetrieveEmergencyActionMessage",
-        eam.callsign,
-        await_response=True,
-    )
+    try:
+        retrieved = await client.send_command(
+            server_id,
+            "RetrieveEmergencyActionMessage",
+            eam.callsign,
+            await_response=True,
+        )
+    except TimeoutError as exc:
+        print(f"Request timed out: {exc}")
+        return
     # Convert MessagePack bytes to an EmergencyActionMessage dataclass
     retrieved_eam = EmergencyActionMessage(**from_bytes(retrieved))
     print("Retrieve response:", retrieved_eam)


### PR DESCRIPTION
## Summary
- catch TimeoutError in the EmergencyManagement example client and print a helpful message instead of exiting
- record the completed timeout-handling task in TASK.md

## Testing
- not run (example-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2bf5f0af083259bff63869b6c74bd