### PR TITLE
Refactor EmergencyManagement client to use helper library

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -57,3 +57,5 @@
 - [x] Handle EmergencyManagement client timeouts gracefully to avoid shutdowns.
 
 
+- [x] Refactor EmergencyManagement client to use shared helper library for API interactions. (2025-09-24)
+

--- a/examples/EmergencyManagement/client/client.py
+++ b/examples/EmergencyManagement/client/client.py
@@ -1,0 +1,90 @@
+"""Helper utilities for the Emergency Management example client."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from reticulum_openapi.client import LXMFClient as BaseLXMFClient
+from reticulum_openapi.codec_msgpack import from_bytes
+from examples.EmergencyManagement.Server.models_emergency import (
+    EmergencyActionMessage,
+)
+
+COMMAND_CREATE_EMERGENCY_ACTION_MESSAGE = "CreateEmergencyActionMessage"
+COMMAND_RETRIEVE_EMERGENCY_ACTION_MESSAGE = "RetrieveEmergencyActionMessage"
+
+LXMFClient = BaseLXMFClient
+
+
+def _decode_emergency_action_message(
+    payload: Optional[bytes],
+) -> EmergencyActionMessage:
+    """Return an :class:`EmergencyActionMessage` decoded from MessagePack bytes.
+
+    Args:
+        payload (Optional[bytes]): MessagePack payload returned by the service.
+
+    Returns:
+        EmergencyActionMessage: Dataclass populated from ``payload``.
+
+    Raises:
+        ValueError: If ``payload`` is ``None`` or not a valid MessagePack document.
+    """
+
+    if payload is None:
+        raise ValueError("Response payload is required")
+
+    data = from_bytes(payload)
+    if not isinstance(data, dict):
+        raise ValueError("Decoded payload must be a mapping")
+    return EmergencyActionMessage(**data)
+
+
+async def create_emergency_action_message(
+    client: LXMFClient,
+    server_identity_hash: str,
+    message: EmergencyActionMessage,
+) -> EmergencyActionMessage:
+    """Create a new emergency action message via the LXMF API.
+
+    Args:
+        client (LXMFClient): Configured LXMF client instance.
+        server_identity_hash (str): Destination server identity hash.
+        message (EmergencyActionMessage): Payload describing the action message to persist.
+
+    Returns:
+        EmergencyActionMessage: Created message returned by the service.
+    """
+
+    response = await client.send_command(
+        server_identity_hash,
+        COMMAND_CREATE_EMERGENCY_ACTION_MESSAGE,
+        message,
+        await_response=True,
+    )
+    return _decode_emergency_action_message(response)
+
+
+async def retrieve_emergency_action_message(
+    client: LXMFClient,
+    server_identity_hash: str,
+    callsign: str,
+) -> EmergencyActionMessage:
+    """Fetch an emergency action message from the LXMF API.
+
+    Args:
+        client (LXMFClient): Configured LXMF client instance.
+        server_identity_hash (str): Destination server identity hash.
+        callsign (str): Callsign identifying the message to retrieve.
+
+    Returns:
+        EmergencyActionMessage: Retrieved message returned by the service.
+    """
+
+    response = await client.send_command(
+        server_identity_hash,
+        COMMAND_RETRIEVE_EMERGENCY_ACTION_MESSAGE,
+        callsign,
+        await_response=True,
+    )
+    return _decode_emergency_action_message(response)

--- a/tests/test_example_emergency_management.py
+++ b/tests/test_example_emergency_management.py
@@ -1,6 +1,5 @@
 """Tests for the Emergency Management example application."""
 
-
 import importlib
 import json
 import asyncio
@@ -183,7 +182,6 @@ def test_server_script_importable_from_directory(monkeypatch) -> None:
     assert "init_db" in globals_ns
 
 
-
 @pytest.mark.asyncio
 async def test_client_main_prints_timeout(monkeypatch, capsys) -> None:
     """The client example prints a timeout message when the path is unavailable."""
@@ -193,12 +191,19 @@ async def test_client_main_prints_timeout(monkeypatch, capsys) -> None:
     class FailingClient:
         """Stub client that always times out when sending commands."""
 
-        def __init__(self) -> None:
+        def __init__(self, *args, **kwargs) -> None:
             self.calls = 0
+
+        @staticmethod
+        def _normalise_destination_hex(value):
+            return value
 
         async def send_command(self, *args, **kwargs):
             self.calls += 1
             raise TimeoutError("Path to destination not available after 10.0 seconds")
+
+        def announce(self) -> None:
+            return None
 
     monkeypatch.setattr(client_module, "LXMFClient", FailingClient)
     monkeypatch.setattr("builtins.input", lambda _: "761dfb354cfe5a3c9d8f5c4465b6c7f5")
@@ -206,7 +211,7 @@ async def test_client_main_prints_timeout(monkeypatch, capsys) -> None:
     await client_module.main()
 
     captured = capsys.readouterr()
-    assert "Timeout: Path to destination not available" in captured.out
+    assert "Request timed out" in captured.out
 
 
 def test_read_server_identity_from_config(tmp_path) -> None:
@@ -264,24 +269,42 @@ async def test_main_uses_configured_identity(monkeypatch, tmp_path) -> None:
     normalise = module.LXMFClient._normalise_destination_hex
 
     class DummyLXMFClient:
-        commands = []
         _normalise_destination_hex = staticmethod(normalise)
 
-        def __init__(self):
+        def __init__(self, *args, **kwargs):
             pass
 
-        async def send_command(self, server_id, command, payload, await_response=True):
-            DummyLXMFClient.commands.append((server_id, command, payload))
-            return b"{}"
+        def announce(self) -> None:
+            return None
 
-    DummyLXMFClient.commands = []
+    interactions = []
+
+    async def fake_create(client, server_id, message):
+        interactions.append(("create", server_id, message))
+        return EmergencyActionMessage(callsign="Bravo1")
+
+    async def fake_retrieve(client, server_id, callsign):
+        interactions.append(("retrieve", server_id, callsign))
+        return EmergencyActionMessage(callsign="Bravo1")
+
     monkeypatch.setattr(module, "LXMFClient", DummyLXMFClient, raising=False)
-    monkeypatch.setattr(module, "from_bytes", lambda payload: {"callsign": "Bravo1"})
+    monkeypatch.setattr(
+        module,
+        "create_emergency_action_message",
+        fake_create,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        module,
+        "retrieve_emergency_action_message",
+        fake_retrieve,
+        raising=False,
+    )
 
     await module.main()
 
-    assert len(DummyLXMFClient.commands) == 2
-    assert all(call[0] == stored_hash for call in DummyLXMFClient.commands)
+    assert len(interactions) == 2
+    assert all(call[1] == stored_hash for call in interactions)
 
 
 @pytest.mark.asyncio
@@ -306,19 +329,37 @@ async def test_main_prompts_when_config_missing(monkeypatch, tmp_path) -> None:
     normalise = module.LXMFClient._normalise_destination_hex
 
     class DummyLXMFClient:
-        commands = []
         _normalise_destination_hex = staticmethod(normalise)
 
-        def __init__(self):
+        def __init__(self, *args, **kwargs):
             pass
 
-        async def send_command(self, server_id, command, payload, await_response=True):
-            DummyLXMFClient.commands.append((server_id, command, payload))
-            return b"{}"
+        def announce(self) -> None:
+            return None
 
-    DummyLXMFClient.commands = []
+    interactions = []
+
+    async def fake_create(client, server_id, message):
+        interactions.append(("create", server_id, message))
+        return EmergencyActionMessage(callsign="Bravo1")
+
+    async def fake_retrieve(client, server_id, callsign):
+        interactions.append(("retrieve", server_id, callsign))
+        return EmergencyActionMessage(callsign="Bravo1")
+
     monkeypatch.setattr(module, "LXMFClient", DummyLXMFClient, raising=False)
-    monkeypatch.setattr(module, "from_bytes", lambda payload: {"callsign": "Bravo1"})
+    monkeypatch.setattr(
+        module,
+        "create_emergency_action_message",
+        fake_create,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        module,
+        "retrieve_emergency_action_message",
+        fake_retrieve,
+        raising=False,
+    )
 
     await module.main()
 
@@ -326,8 +367,8 @@ async def test_main_prompts_when_config_missing(monkeypatch, tmp_path) -> None:
     prompt_text = prompts[0]
     assert "hexadecimal" in prompt_text
     assert "e.g." in prompt_text
-    assert len(DummyLXMFClient.commands) == 2
-    assert all(call[0] == entered_hash.strip() for call in DummyLXMFClient.commands)
+    assert len(interactions) == 2
+    assert all(call[1] == entered_hash.strip() for call in interactions)
 
 
 @pytest.mark.asyncio
@@ -356,22 +397,84 @@ async def test_main_prompts_when_config_invalid(monkeypatch, tmp_path) -> None:
     normalise = module.LXMFClient._normalise_destination_hex
 
     class DummyLXMFClient:
-        commands = []
         _normalise_destination_hex = staticmethod(normalise)
 
-        def __init__(self):
+        def __init__(self, *args, **kwargs):
             pass
 
-        async def send_command(self, server_id, command, payload, await_response=True):
-            DummyLXMFClient.commands.append((server_id, command, payload))
-            return b"{}"
+        def announce(self) -> None:
+            return None
 
-    DummyLXMFClient.commands = []
+    interactions = []
+
+    async def fake_create(client, server_id, message):
+        interactions.append(("create", server_id, message))
+        return EmergencyActionMessage(callsign="Bravo1")
+
+    async def fake_retrieve(client, server_id, callsign):
+        interactions.append(("retrieve", server_id, callsign))
+        return EmergencyActionMessage(callsign="Bravo1")
+
     monkeypatch.setattr(module, "LXMFClient", DummyLXMFClient, raising=False)
-    monkeypatch.setattr(module, "from_bytes", lambda payload: {"callsign": "Bravo1"})
+    monkeypatch.setattr(
+        module,
+        "create_emergency_action_message",
+        fake_create,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        module,
+        "retrieve_emergency_action_message",
+        fake_retrieve,
+        raising=False,
+    )
 
     await module.main()
 
     assert prompts
-    assert len(DummyLXMFClient.commands) == 2
-    assert all(call[0] == entered_hash.strip() for call in DummyLXMFClient.commands)
+    assert len(interactions) == 2
+    assert all(call[1] == entered_hash.strip() for call in interactions)
+
+
+@pytest.mark.asyncio
+async def test_create_helper_decodes_payload() -> None:
+    """The helper wraps ``send_command`` and decodes the response dataclass."""
+
+    from examples.EmergencyManagement.client import client as client_lib
+
+    message = EmergencyActionMessage(callsign="Helper", commsMethod="HF")
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.calls = []
+
+        async def send_command(self, server_id, command, payload, await_response=True):
+            self.calls.append((server_id, command, payload, await_response))
+            return dataclass_to_msgpack(message)
+
+    client = DummyClient()
+    result = await client_lib.create_emergency_action_message(
+        client, "AA" * 32, message
+    )
+
+    assert result == message
+    assert client.calls
+    sent = client.calls[0]
+    assert sent[1] == client_lib.COMMAND_CREATE_EMERGENCY_ACTION_MESSAGE
+    assert sent[3] is True
+
+
+@pytest.mark.asyncio
+async def test_retrieve_helper_raises_for_invalid_payload() -> None:
+    """A non-mapping payload results in a ``ValueError``."""
+
+    from examples.EmergencyManagement.client import client as client_lib
+
+    class DummyClient:
+        async def send_command(self, server_id, command, payload, await_response=True):
+            return dataclass_to_msgpack("not-a-mapping")
+
+    client = DummyClient()
+
+    with pytest.raises(ValueError):
+        await client_lib.retrieve_emergency_action_message(client, "BB" * 32, "Call")


### PR DESCRIPTION
## Summary
- add an Emergency Management client helper module that wraps LXMF command interactions and decoding
- refactor `client_emergency.py` to build on the shared helper while keeping configuration handling intact
- extend and adjust tests to cover the new helper functions and the refactored client flow, and record the work in `TASK.md`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2ca0c26f883258989605b04364ef2