### PR TITLE
Fix lint issues in emergency service and core service module

### DIFF
--- a/examples/EmergencyManagement/Server/server_emergency.py
+++ b/examples/EmergencyManagement/Server/server_emergency.py
@@ -3,9 +3,8 @@
 
 import asyncio
 import signal
-from contextlib import suppress
-from pathlib import Path
 import sys
+from contextlib import suppress
 from pathlib import Path
 
 
@@ -72,6 +71,7 @@ def _configure_environment() -> None:
 EmergencyService = object()
 init_db = None
 
+
 def _ensure_dependencies_loaded() -> None:
     """Load modules that require adjusted import paths."""
 
@@ -90,6 +90,7 @@ def _ensure_dependencies_loaded() -> None:
 
     init_db = database_init_db
     EmergencyService = service_emergency_service
+
 
 _configure_environment()
 
@@ -131,7 +132,6 @@ except Exception:  # pragma: no cover - best effort for optional imports
     EmergencyService = None
 
 
-
 async def main() -> None:
     """Run the emergency management service until interrupted.
 
@@ -140,14 +140,10 @@ async def main() -> None:
         and the service begins shutting down.
     """
 
-
-
     _ensure_dependencies_loaded()
 
     if init_db is None or not isinstance(EmergencyService, type):
         raise RuntimeError("Emergency service dependencies failed to load")
-
-
     _configure_environment()
     await init_db()
     async with EmergencyService() as svc:
@@ -158,6 +154,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    import asyncio
-
     asyncio.run(main())

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -8,10 +8,8 @@ from dataclasses import is_dataclass
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import Any
 from typing import Optional
 from typing import Type
-from .model import dataclass_to_json  # Add this import alongside other model imports
 
 import LXMF
 import RNS
@@ -31,33 +29,6 @@ from .model import dataclass_to_msgpack
 
 configure_logging()
 logger = logging.getLogger(__name__)
-
-
-def _convert_dataclasses_to_primitives(value: Any) -> Any:
-    """Convert dataclasses within the value into primitive containers.
-
-    Args:
-        value (Any): Value potentially containing dataclasses.
-
-    Returns:
-        Any: Value with dataclasses recursively converted to dictionaries.
-    """
-
-    if is_dataclass(value):
-        return {
-            key: _convert_dataclasses_to_primitives(item)
-            for key, item in asdict(value).items()
-        }
-    if isinstance(value, dict):
-        return {
-            key: _convert_dataclasses_to_primitives(item)
-            for key, item in value.items()
-        }
-    if isinstance(value, (list, tuple, set, frozenset)):
-        return [
-            _convert_dataclasses_to_primitives(item) for item in value
-        ]
-    return value
 
 
 def _normalise_for_msgpack(value: Any) -> Any:

--- a/tests/test_example_emergency_management.py
+++ b/tests/test_example_emergency_management.py
@@ -2,8 +2,6 @@
 
 import importlib
 import json
-import asyncio
-
 import runpy
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- deduplicate imports and tighten blank-line spacing in the emergency server example to satisfy flake8
- remove unused imports and helper duplication in the shared service module
- drop an unused asyncio import from the emergency management tests

## Testing
- flake8 --exclude=venv_linux
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2d344c574832591f3e70a85d85dd6