### PR TITLE
Add FastAPI web gateway for EmergencyManagement example

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -59,3 +59,5 @@
 
 - [x] Refactor EmergencyManagement client to use shared helper library for API interactions. (2025-09-24)
 
+- [x] Add FastAPI web gateway and API tests for EmergencyManagement example. (2025-09-23)
+

--- a/examples/EmergencyManagement/web_gateway/app.py
+++ b/examples/EmergencyManagement/web_gateway/app.py
@@ -1,0 +1,327 @@
+"""FastAPI gateway for the Emergency Management LXMF service."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, get_args, get_origin
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, status
+from fastapi.responses import JSONResponse
+
+from examples.EmergencyManagement.Server.models_emergency import (
+    EmergencyActionMessage,
+    Event,
+)
+from examples.EmergencyManagement.client.client import LXMFClient
+from examples.EmergencyManagement.client.client_emergency import (
+    CLIENT_DISPLAY_NAME_KEY,
+    CONFIG_PATH,
+    DEFAULT_DISPLAY_NAME,
+    DEFAULT_TIMEOUT_SECONDS,
+    LXMF_CONFIG_PATH_KEY,
+    LXMF_STORAGE_PATH_KEY,
+    REQUEST_TIMEOUT_KEY,
+    load_client_config,
+    read_server_identity_from_config,
+)
+from reticulum_openapi.codec_msgpack import from_bytes
+
+
+COMMAND_CREATE_EAM = "CreateEmergencyActionMessage"
+COMMAND_DELETE_EAM = "DeleteEmergencyActionMessage"
+COMMAND_LIST_EAM = "ListEmergencyActionMessage"
+COMMAND_PUT_EAM = "PutEmergencyActionMessage"
+COMMAND_RETRIEVE_EAM = "RetrieveEmergencyActionMessage"
+
+COMMAND_CREATE_EVENT = "CreateEvent"
+COMMAND_DELETE_EVENT = "DeleteEvent"
+COMMAND_LIST_EVENT = "ListEvent"
+COMMAND_PUT_EVENT = "PutEvent"
+COMMAND_RETRIEVE_EVENT = "RetrieveEvent"
+
+
+ConfigDict = Dict[str, Any]
+T = TypeVar("T")
+
+app = FastAPI(title="Emergency Management Gateway")
+
+_CONFIG_DATA: ConfigDict = load_client_config(CONFIG_PATH)
+_DEFAULT_SERVER_IDENTITY: Optional[str] = read_server_identity_from_config(
+    CONFIG_PATH, _CONFIG_DATA
+)
+_CLIENT_INSTANCE: Optional[LXMFClient] = None
+
+
+def _normalise_optional_path(value: Optional[str]) -> Optional[str]:
+    """Return a stripped path string or ``None`` when empty."""
+
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned or None
+    return None
+
+
+def _resolve_timeout(config: ConfigDict) -> float:
+    """Return the timeout value configured for the client."""
+
+    timeout_setting = config.get(REQUEST_TIMEOUT_KEY)
+    if isinstance(timeout_setting, (int, float)) and timeout_setting > 0:
+        return float(timeout_setting)
+    return DEFAULT_TIMEOUT_SECONDS
+
+
+def _resolve_display_name(config: ConfigDict) -> str:
+    """Return the configured display name or the default when missing."""
+
+    display_name = config.get(CLIENT_DISPLAY_NAME_KEY)
+    if isinstance(display_name, str) and display_name.strip():
+        return display_name.strip()
+    return DEFAULT_DISPLAY_NAME
+
+
+def _create_client_from_config() -> LXMFClient:
+    """Instantiate the shared LXMF client based on configuration data."""
+
+    config_path_override = _normalise_optional_path(
+        _CONFIG_DATA.get(LXMF_CONFIG_PATH_KEY)
+    )
+    storage_path_override = _normalise_optional_path(
+        _CONFIG_DATA.get(LXMF_STORAGE_PATH_KEY)
+    )
+    timeout_seconds = _resolve_timeout(_CONFIG_DATA)
+    display_name = _resolve_display_name(_CONFIG_DATA)
+
+    client = LXMFClient(
+        config_path=config_path_override,
+        storage_path=storage_path_override,
+        display_name=display_name,
+        timeout=timeout_seconds,
+    )
+    client.announce()
+    return client
+
+
+def get_shared_client() -> LXMFClient:
+    """Return the shared LXMF client, creating it if necessary."""
+
+    global _CLIENT_INSTANCE
+    if _CLIENT_INSTANCE is None:
+        _CLIENT_INSTANCE = _create_client_from_config()
+    return _CLIENT_INSTANCE
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    """Ensure the LXMF client is ready before serving requests."""
+
+    get_shared_client()
+
+
+def _convert_value(expected_type: Type[Any], value: Any) -> Any:
+    """Recursively convert JSON values to dataclass field types."""
+
+    origin = get_origin(expected_type)
+    if origin is Union:
+        for arg in get_args(expected_type):
+            if arg is type(None):
+                if value is None:
+                    return None
+                continue
+            try:
+                return _convert_value(arg, value)
+            except (TypeError, ValueError):
+                continue
+        raise ValueError(f"Unable to match value {value!r} to type {expected_type}")
+    if origin in (list, List):
+        if not isinstance(value, list):
+            raise TypeError(f"Expected list for type {expected_type}")
+        item_type = get_args(expected_type)[0]
+        return [_convert_value(item_type, item) for item in value]
+    if is_dataclass(expected_type):
+        if not isinstance(value, dict):
+            raise TypeError(f"Expected object for dataclass {expected_type.__name__}")
+        return _build_dataclass(expected_type, value)
+    return value
+
+
+def _build_dataclass(cls: Type[T], data: Dict[str, Any]) -> T:
+    """Build a dataclass instance from primitive JSON data."""
+
+    if not isinstance(data, dict):
+        raise TypeError("Request payload must be a JSON object")
+
+    kwargs: Dict[str, Any] = {}
+    for field in fields(cls):
+        if field.name in data:
+            kwargs[field.name] = _convert_value(field.type, data[field.name])
+    return cls(**kwargs)
+
+
+async def _send_command(
+    server_identity: str,
+    command: str,
+    payload: Optional[object],
+) -> JSONResponse:
+    """Send a command through LXMF and return the decoded response."""
+
+    client = get_shared_client()
+    try:
+        response = await client.send_command(
+            server_identity,
+            command,
+            payload,
+            await_response=True,
+        )
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:  # pragma: no cover - defensive path
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+
+    if response is None:
+        return JSONResponse(content=None)
+    data = from_bytes(response)
+    return JSONResponse(content=data)
+
+
+async def _resolve_server_identity(
+    server_identity_query: Optional[str] = Query(None, alias="server_identity"),
+    server_identity_header: Optional[str] = Header(None, alias="X-Server-Identity"),
+) -> str:
+    """Determine the destination server identity hash for a request."""
+
+    candidate = (
+        server_identity_query
+        or server_identity_header
+        or _DEFAULT_SERVER_IDENTITY
+    )
+    if candidate is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Server identity hash is required",
+        )
+    try:
+        return LXMFClient._normalise_destination_hex(candidate)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
+
+@app.post("/emergency-action-messages")
+async def create_emergency_action_message(
+    payload: Dict[str, Any],
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """Create a new emergency action message via LXMF."""
+
+    message = _build_dataclass(EmergencyActionMessage, payload)
+    return await _send_command(server_identity, COMMAND_CREATE_EAM, message)
+
+
+@app.delete("/emergency-action-messages/{callsign}")
+async def delete_emergency_action_message(
+    callsign: str,
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """Delete an emergency action message by callsign."""
+
+    return await _send_command(server_identity, COMMAND_DELETE_EAM, callsign)
+
+
+@app.get("/emergency-action-messages")
+async def list_emergency_action_messages(
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """List stored emergency action messages."""
+
+    return await _send_command(server_identity, COMMAND_LIST_EAM, None)
+
+
+@app.put("/emergency-action-messages/{callsign}")
+async def update_emergency_action_message(
+    callsign: str,
+    payload: Dict[str, Any],
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """Update an existing emergency action message."""
+
+    payload = dict(payload)
+    payload["callsign"] = callsign
+    message = _build_dataclass(EmergencyActionMessage, payload)
+    return await _send_command(server_identity, COMMAND_PUT_EAM, message)
+
+
+@app.get("/emergency-action-messages/{callsign}")
+async def retrieve_emergency_action_message(
+    callsign: str,
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """Retrieve an emergency action message by callsign."""
+
+    return await _send_command(server_identity, COMMAND_RETRIEVE_EAM, callsign)
+
+
+@app.post("/events")
+async def create_event(
+    payload: Dict[str, Any],
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """Create a new event record via LXMF."""
+
+    event = _build_dataclass(Event, payload)
+    return await _send_command(server_identity, COMMAND_CREATE_EVENT, event)
+
+
+@app.delete("/events/{uid}")
+async def delete_event(
+    uid: str,
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """Delete an event by unique identifier."""
+
+    return await _send_command(server_identity, COMMAND_DELETE_EVENT, uid)
+
+
+@app.get("/events")
+async def list_events(
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """List events stored on the server."""
+
+    return await _send_command(server_identity, COMMAND_LIST_EVENT, None)
+
+
+@app.put("/events/{uid}")
+async def update_event(
+    uid: int,
+    payload: Dict[str, Any],
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """Update an existing event by unique identifier."""
+
+    payload = dict(payload)
+    payload["uid"] = uid
+    event = _build_dataclass(Event, payload)
+    return await _send_command(server_identity, COMMAND_PUT_EVENT, event)
+
+
+@app.get("/events/{uid}")
+async def retrieve_event(
+    uid: str,
+    server_identity: str = Depends(_resolve_server_identity),
+) -> JSONResponse:
+    """Retrieve an event by unique identifier."""
+
+    return await _send_command(server_identity, COMMAND_RETRIEVE_EVENT, uid)

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example applications for Reticulum OpenAPI."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ RNS
 LXMF
 SQLAlchemy
 jsonschema
+fastapi
+httpx
 msgpack
 pytest
 pytest-asyncio

--- a/tests/examples/emergency_management/test_web_gateway.py
+++ b/tests/examples/emergency_management/test_web_gateway.py
@@ -1,0 +1,187 @@
+"""Tests for the Emergency Management FastAPI gateway."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from examples.EmergencyManagement.Server.models_emergency import (
+    EmergencyActionMessage,
+    Event,
+)
+from examples.EmergencyManagement.client.client import LXMFClient as RealLXMFClient
+from reticulum_openapi.codec_msgpack import to_canonical_bytes
+
+
+SERVER_IDENTITY = "00112233445566778899aabbccddeeff"
+
+
+@pytest.fixture()
+def gateway_app(monkeypatch):
+    """Provide a configured TestClient and captured LXMF client instance."""
+
+    module = importlib.import_module(
+        "examples.EmergencyManagement.web_gateway.app"
+    )
+    module = importlib.reload(module)
+
+    created_clients: List["StubClient"] = []
+
+    class StubClient:
+        """Stub LXMF client capturing send_command usage."""
+
+        _normalise_destination_hex = staticmethod(
+            RealLXMFClient._normalise_destination_hex
+        )
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.send_command: AsyncMock = AsyncMock()
+            self.announce_called = False
+            created_clients.append(self)
+
+        def announce(self) -> None:
+            self.announce_called = True
+
+    monkeypatch.setattr(module, "LXMFClient", StubClient)
+
+    with TestClient(module.app) as client:
+        if not created_clients:
+            raise AssertionError("LXMF client was not created on startup")
+        stub = created_clients[0]
+        stub.send_command.reset_mock()
+        yield module, client, stub
+
+    module._CLIENT_INSTANCE = None
+
+
+def test_create_emergency_action_message_routes_payload(gateway_app) -> None:
+    """Creating an EAM should convert payloads to dataclasses and decode responses."""
+
+    module, client, stub = gateway_app
+    stub.send_command.return_value = to_canonical_bytes(
+        {"callsign": "Alpha", "groupName": "Team"}
+    )
+
+    response = client.post(
+        "/emergency-action-messages",
+        params={"server_identity": SERVER_IDENTITY},
+        json={"callsign": "Alpha", "groupName": "Team"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"callsign": "Alpha", "groupName": "Team"}
+
+    assert stub.send_command.await_count == 1
+    args, kwargs = stub.send_command.await_args
+    assert args[0] == SERVER_IDENTITY
+    assert args[1] == module.COMMAND_CREATE_EAM
+    assert isinstance(args[2], EmergencyActionMessage)
+    assert args[2].callsign == "Alpha"
+    assert kwargs["await_response"] is True
+
+
+def test_list_emergency_action_messages_decodes_messagepack(gateway_app) -> None:
+    """Listing EAMs should decode MessagePack arrays to JSON lists."""
+
+    module, client, stub = gateway_app
+    stub.send_command.return_value = to_canonical_bytes(
+        [{"callsign": "Alpha"}, {"callsign": "Bravo"}]
+    )
+
+    response = client.get(
+        "/emergency-action-messages",
+        params={"server_identity": SERVER_IDENTITY},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == [{"callsign": "Alpha"}, {"callsign": "Bravo"}]
+
+    args, _ = stub.send_command.await_args
+    assert args[0] == SERVER_IDENTITY
+    assert args[1] == module.COMMAND_LIST_EAM
+    assert args[2] is None
+
+
+def test_update_event_uses_path_identifier(gateway_app) -> None:
+    """Updating events should merge the path UID into the dataclass payload."""
+
+    module, client, stub = gateway_app
+    stub.send_command.return_value = to_canonical_bytes(
+        {"uid": 21, "type": "Updated"}
+    )
+
+    response = client.put(
+        "/events/21",
+        params={"server_identity": SERVER_IDENTITY},
+        json={"type": "Updated"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"uid": 21, "type": "Updated"}
+
+    args, kwargs = stub.send_command.await_args
+    assert args[0] == SERVER_IDENTITY
+    assert args[1] == module.COMMAND_PUT_EVENT
+    assert isinstance(args[2], Event)
+    assert args[2].uid == 21
+    assert kwargs["await_response"] is True
+
+
+def test_delete_event_sends_identifier_string(gateway_app) -> None:
+    """Deleting events should forward the identifier as provided."""
+
+    module, client, stub = gateway_app
+    stub.send_command.return_value = to_canonical_bytes(
+        {"status": "deleted", "uid": "21"}
+    )
+
+    response = client.delete(
+        "/events/21",
+        params={"server_identity": SERVER_IDENTITY},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "deleted", "uid": "21"}
+
+    args, _ = stub.send_command.await_args
+    assert args[0] == SERVER_IDENTITY
+    assert args[1] == module.COMMAND_DELETE_EVENT
+    assert args[2] == "21"
+
+
+def test_timeout_returns_gateway_timeout(gateway_app) -> None:
+    """Transport timeouts are surfaced as HTTP 504 errors."""
+
+    module, client, stub = gateway_app
+    stub.send_command.side_effect = TimeoutError("path unavailable")
+
+    response = client.get(
+        "/events",
+        params={"server_identity": SERVER_IDENTITY},
+    )
+
+    assert response.status_code == 504
+    assert "path unavailable" in response.json()["detail"]
+
+
+def test_invalid_server_identity_returns_422(gateway_app) -> None:
+    """Invalid server identity hashes should fail validation."""
+
+    _module, client, _stub = gateway_app
+
+    response = client.get(
+        "/events",
+        params={"server_identity": "not-hex"},
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add a FastAPI web gateway that shares the EmergencyManagement LXMF client configuration and exposes REST endpoints for each service command
- decode LXMF responses from MessagePack and validate destination identity input before relaying results
- add dedicated pytest coverage for the gateway and include FastAPI/httpx dependencies

## Testing
- pytest tests/examples/emergency_management/test_web_gateway.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d4b3fb908325a9a70a41c4e3c230