### PR TITLE
Add emergency action messages UI with API integration and tests

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -62,3 +62,6 @@
 
 - [x] Add FastAPI web gateway and API tests for EmergencyManagement example. (2025-09-23)
 
+- [x] Build Emergency Action Messages web UI with CRUD flows, optimistic toasts, and
+  Vitest coverage. (2025-09-23)
+

--- a/examples/EmergencyManagement/webui/README.md
+++ b/examples/EmergencyManagement/webui/README.md
@@ -32,11 +32,16 @@ npm run dev     # Start the development server
 npm run build   # Build the production bundle
 npm run preview # Preview the production build locally
 npm run lint    # Run ESLint checks
+npm run test    # Execute Vitest + React Testing Library suites
 ```
 
 ## Project structure
 
 - `src/router` wires up React Router for the dashboard, message, and event pages.
 - `src/components/layout` contains the sidebar and mesh status top bar layout.
-- `src/lib/apiClient.ts` exposes an Axios instance that normalises the gateway URL.
+- `src/components/toast` implements optimistic success and error toast notifications.
+- `src/lib/apiClient.ts` exposes an Axios instance that normalises the gateway URL and
+  typed helpers for the FastAPI emergency message endpoints.
+- `src/pages/EmergencyActionMessages` provides the interactive tables, forms, and
+  dialogs that manage messages end-to-end.
 - `src/pages` contains feature placeholders that can be expanded with real data.

--- a/examples/EmergencyManagement/webui/package-lock.json
+++ b/examples/EmergencyManagement/webui/package-lock.json
@@ -14,6 +14,9 @@
         "react-router-dom": "^6.28.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.2.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -22,9 +25,39 @@
         "eslint": "^8.55.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "jsdom": "^26.0.0",
         "typescript": "^5.2.2",
-        "vite": "^5.0.8"
+        "vite": "^5.0.8",
+        "vitest": "^2.1.3"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -280,6 +313,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -326,6 +369,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1280,6 +1438,104 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1600,6 +1856,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1621,6 +1990,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1673,6 +2052,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1681,6 +2070,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -1774,6 +2173,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1818,6 +2227,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1833,6 +2259,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -1896,12 +2332,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1921,6 +2392,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1935,6 +2423,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dir-glob": {
@@ -1963,6 +2461,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1984,6 +2490,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2001,6 +2520,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2279,6 +2805,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2287,6 +2823,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2693,6 +3239,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2728,6 +3328,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -2792,6 +3402,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2816,6 +3433,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -2924,6 +3581,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2932,6 +3596,27 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2988,6 +3673,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -3041,6 +3736,13 @@
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3117,6 +3819,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3155,6 +3870,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3214,6 +3946,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proxy-from-env": {
@@ -3278,6 +4040,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3318,6 +4088,20 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -3400,6 +4184,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3422,6 +4213,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3469,6 +4280,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3489,6 +4307,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3497,6 +4329,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -3528,10 +4373,81 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3546,6 +4462,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3702,6 +4644,155 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3716,6 +4807,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -3734,6 +4842,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/examples/EmergencyManagement/webui/package.json
+++ b/examples/EmergencyManagement/webui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.12.2",
@@ -16,6 +17,9 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -24,7 +28,9 @@
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "jsdom": "^26.0.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^5.0.8",
+    "vitest": "^2.1.3"
   }
 }

--- a/examples/EmergencyManagement/webui/src/App.tsx
+++ b/examples/EmergencyManagement/webui/src/App.tsx
@@ -1,9 +1,14 @@
 import { RouterProvider } from 'react-router-dom';
 
+import { ToastProvider } from './components/toast';
 import { router } from './router';
 
 function App(): JSX.Element {
-  return <RouterProvider router={router} />;
+  return (
+    <ToastProvider>
+      <RouterProvider router={router} />
+    </ToastProvider>
+  );
 }
 
 export default App;

--- a/examples/EmergencyManagement/webui/src/components/toast/ToastContext.ts
+++ b/examples/EmergencyManagement/webui/src/components/toast/ToastContext.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+export interface ToastOptions {
+  message: string;
+  type?: ToastType;
+  durationMs?: number;
+}
+
+export interface ToastContextValue {
+  pushToast: (options: ToastOptions) => void;
+  dismissToast: (id: string) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | undefined>(undefined);

--- a/examples/EmergencyManagement/webui/src/components/toast/ToastProvider.tsx
+++ b/examples/EmergencyManagement/webui/src/components/toast/ToastProvider.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+
+import { ToastContext, type ToastContextValue, type ToastOptions } from './ToastContext';
+
+const DEFAULT_DURATION_MS = 4000;
+
+interface Toast extends Required<ToastOptions> {
+  id: string;
+}
+
+function generateToastId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function ToastProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismissToast = useCallback<ToastContextValue['dismissToast']>((id) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const pushToast = useCallback<ToastContextValue['pushToast']>(
+    ({ message, type = 'info', durationMs = DEFAULT_DURATION_MS }) => {
+      const id = generateToastId();
+      const toast: Toast = { id, message, type, durationMs };
+      setToasts((current) => [...current, toast]);
+      window.setTimeout(() => dismissToast(id), durationMs);
+    },
+    [dismissToast],
+  );
+
+  const value = useMemo<ToastContextValue>(
+    () => ({
+      pushToast,
+      dismissToast,
+    }),
+    [pushToast, dismissToast],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="toast-container" role="status" aria-live="polite">
+        {toasts.map((toast) => (
+          <div key={toast.id} className={`toast toast-${toast.type}`}>
+            <span>{toast.message}</span>
+            <button
+              type="button"
+              className="toast-dismiss"
+              onClick={() => dismissToast(toast.id)}
+              aria-label="Dismiss notification"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/examples/EmergencyManagement/webui/src/components/toast/index.ts
+++ b/examples/EmergencyManagement/webui/src/components/toast/index.ts
@@ -1,0 +1,3 @@
+export { ToastProvider } from './ToastProvider';
+export { useToast } from './useToast';
+export type { ToastOptions, ToastType, ToastContextValue } from './ToastContext';

--- a/examples/EmergencyManagement/webui/src/components/toast/useToast.ts
+++ b/examples/EmergencyManagement/webui/src/components/toast/useToast.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+
+import { ToastContext, type ToastContextValue } from './ToastContext';
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider.');
+  }
+  return context;
+}

--- a/examples/EmergencyManagement/webui/src/index.css
+++ b/examples/EmergencyManagement/webui/src/index.css
@@ -156,3 +156,230 @@ body {
 .page-definition-list dd {
   margin: 0;
 }
+.page-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.messages-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.messages-table-controls {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.messages-table table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #f8fafc;
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.messages-table th,
+.messages-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.messages-table tbody tr {
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.messages-table tbody tr:hover,
+.messages-table-row-selected {
+  background-color: rgba(56, 189, 248, 0.12);
+}
+
+.messages-table-empty {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #64748b;
+}
+
+.field-label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.form-field label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.form-field input,
+.form-field select,
+.messages-table input,
+.messages-table select {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.5rem;
+  font-size: 0.95rem;
+  background-color: #ffffff;
+}
+
+.field-error {
+  color: #dc2626;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.primary-button,
+.secondary-button,
+.danger-button {
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+
+.primary-button {
+  background-color: #2563eb;
+  color: #ffffff;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.secondary-button {
+  background-color: #e2e8f0;
+  color: #0f172a;
+}
+
+.danger-button {
+  background-color: #dc2626;
+  color: #ffffff;
+}
+
+.primary-button:hover:not(:disabled),
+.secondary-button:hover,
+.danger-button:hover {
+  filter: brightness(0.95);
+}
+
+.message-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.message-details-empty {
+  color: #64748b;
+}
+
+.message-details-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.message-details-subtitle {
+  margin: 0.25rem 0 0;
+  color: #475569;
+}
+
+.message-details-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.message-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.message-form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.55);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-card {
+  background-color: #ffffff;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.2);
+  max-width: 420px;
+  width: 90%;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 1100;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  min-width: 240px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
+  color: #0f172a;
+}
+
+.toast-success {
+  background-color: #bbf7d0;
+}
+
+.toast-error {
+  background-color: #fecdd3;
+}
+
+.toast-info {
+  background-color: #bfdbfe;
+}
+
+.toast-dismiss {
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+}

--- a/examples/EmergencyManagement/webui/src/lib/apiClient.ts
+++ b/examples/EmergencyManagement/webui/src/lib/apiClient.ts
@@ -1,0 +1,101 @@
+import axios, { AxiosError } from 'axios';
+
+export type EAMStatus = 'Red' | 'Yellow' | 'Green';
+
+export interface EmergencyActionMessage {
+  callsign: string;
+  groupName?: string | null;
+  securityStatus?: EAMStatus | null;
+  securityCapability?: EAMStatus | null;
+  preparednessStatus?: EAMStatus | null;
+  medicalStatus?: EAMStatus | null;
+  mobilityStatus?: EAMStatus | null;
+  commsStatus?: EAMStatus | null;
+  commsMethod?: string | null;
+}
+
+export interface DeleteEmergencyActionMessageResponse {
+  status: 'deleted' | 'not_found';
+  callsign: string;
+}
+
+const apiBaseUrl = (import.meta.env?.VITE_API_BASE_URL as string | undefined) ??
+  'http://localhost:8000';
+const serverIdentity = (import.meta.env?.VITE_SERVER_IDENTITY as string | undefined)?.trim();
+
+export function getApiBaseUrl(): string {
+  return apiBaseUrl;
+}
+
+export const apiClient = axios.create({
+  baseURL: apiBaseUrl,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+if (serverIdentity) {
+  apiClient.defaults.headers.common['X-Server-Identity'] = serverIdentity;
+}
+
+export async function listEmergencyActionMessages(): Promise<EmergencyActionMessage[]> {
+  const response = await apiClient.get<EmergencyActionMessage[] | null>(
+    '/emergency-action-messages',
+  );
+  return response.data ?? [];
+}
+
+export async function retrieveEmergencyActionMessage(
+  callsign: string,
+): Promise<EmergencyActionMessage | null> {
+  const response = await apiClient.get<EmergencyActionMessage | null>(
+    `/emergency-action-messages/${encodeURIComponent(callsign)}`,
+  );
+  return response.data ?? null;
+}
+
+export async function createEmergencyActionMessage(
+  message: EmergencyActionMessage,
+): Promise<EmergencyActionMessage> {
+  const response = await apiClient.post<EmergencyActionMessage>(
+    '/emergency-action-messages',
+    message,
+  );
+  return response.data;
+}
+
+export async function updateEmergencyActionMessage(
+  message: EmergencyActionMessage,
+): Promise<EmergencyActionMessage | null> {
+  const response = await apiClient.put<EmergencyActionMessage | null>(
+    `/emergency-action-messages/${encodeURIComponent(message.callsign)}`,
+    message,
+  );
+  return response.data ?? null;
+}
+
+export async function deleteEmergencyActionMessage(
+  callsign: string,
+): Promise<DeleteEmergencyActionMessageResponse> {
+  const response = await apiClient.delete<DeleteEmergencyActionMessageResponse>(
+    `/emergency-action-messages/${encodeURIComponent(callsign)}`,
+  );
+  return response.data;
+}
+
+export function extractApiErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const axiosError = error as AxiosError<{ detail?: string }>;
+    const detail = axiosError.response?.data?.detail;
+    if (typeof detail === 'string' && detail.trim()) {
+      return detail;
+    }
+    if (typeof axiosError.message === 'string' && axiosError.message.trim()) {
+      return axiosError.message;
+    }
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return 'Unexpected error communicating with the gateway.';
+}

--- a/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/DeleteMessageDialog.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/DeleteMessageDialog.tsx
@@ -1,0 +1,37 @@
+interface DeleteMessageDialogProps {
+  callsign: string | null;
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteMessageDialog({
+  callsign,
+  isOpen,
+  onCancel,
+  onConfirm,
+}: DeleteMessageDialogProps): JSX.Element | null {
+  if (!isOpen || !callsign) {
+    return null;
+  }
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal-card">
+        <h3>Delete message</h3>
+        <p>
+          Are you sure you want to delete the message for <strong>{callsign}</strong>? This
+          action cannot be undone.
+        </p>
+        <div className="modal-actions">
+          <button type="button" className="secondary-button" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" className="danger-button" onClick={onConfirm}>
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/EmergencyActionMessagesPage.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/EmergencyActionMessagesPage.tsx
@@ -1,0 +1,269 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  createEmergencyActionMessage,
+  deleteEmergencyActionMessage,
+  extractApiErrorMessage,
+  listEmergencyActionMessages,
+  updateEmergencyActionMessage,
+  type EmergencyActionMessage,
+} from '../../lib/apiClient';
+import { useToast } from '../../components/toast';
+
+import { DeleteMessageDialog } from './DeleteMessageDialog';
+import { MessageDetails } from './MessageDetails';
+import { MessageForm, type MessageFormMode } from './MessageForm';
+import { MessagesTable } from './MessagesTable';
+
+function cloneMessages(messages: EmergencyActionMessage[]): EmergencyActionMessage[] {
+  return messages.map((message) => ({ ...message }));
+}
+
+export function EmergencyActionMessagesPage(): JSX.Element {
+  const [messages, setMessages] = useState<EmergencyActionMessage[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selectedCallsign, setSelectedCallsign] = useState<string | null>(null);
+  const [formMode, setFormMode] = useState<MessageFormMode>('create');
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
+
+  const { pushToast } = useToast();
+  const messagesRef = useRef<EmergencyActionMessage[]>(messages);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  const selectedMessage = useMemo(() => {
+    return messages.find((message) => message.callsign === selectedCallsign) ?? null;
+  }, [messages, selectedCallsign]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchMessages = async () => {
+      try {
+        const items = await listEmergencyActionMessages();
+        if (!isMounted) {
+          return;
+        }
+        setMessages(items);
+        setSelectedCallsign(items[0]?.callsign ?? null);
+        setLoadError(null);
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+        const message = extractApiErrorMessage(error);
+        setLoadError(message);
+        pushToast({ type: 'error', message: `Failed to load messages: ${message}` });
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchMessages();
+    return () => {
+      isMounted = false;
+    };
+  }, [pushToast]);
+
+  useEffect(() => {
+    if (selectedMessage) {
+      setFormMode('edit');
+    } else {
+      setFormMode('create');
+    }
+  }, [selectedMessage]);
+
+  const handleSelectMessage = useCallback((callsign: string) => {
+    setSelectedCallsign(callsign);
+  }, []);
+
+  const handleResetForm = useCallback(() => {
+    setSelectedCallsign(null);
+    setFormMode('create');
+  }, []);
+
+  const handleCreate = useCallback(
+    async (message: EmergencyActionMessage) => {
+      const previousMessages = cloneMessages(messagesRef.current);
+      setIsSubmitting(true);
+      pushToast({ type: 'info', message: `Saving message ${message.callsign}…` });
+      setMessages((current) => {
+        const hasExisting = current.some((item) => item.callsign === message.callsign);
+        if (hasExisting) {
+          return current.map((item) =>
+            item.callsign === message.callsign ? { ...item, ...message } : item,
+          );
+        }
+        return [...current, { ...message }];
+      });
+      setSelectedCallsign(message.callsign);
+
+      try {
+        const saved = await createEmergencyActionMessage(message);
+        setMessages((current) =>
+          current.map((item) =>
+            item.callsign === saved.callsign ? { ...item, ...saved } : item,
+          ),
+        );
+        pushToast({ type: 'success', message: `Gateway confirmed ${message.callsign}.` });
+      } catch (error) {
+        const errorMessage = extractApiErrorMessage(error);
+        setMessages(previousMessages);
+        const previousSelection = previousMessages.find(
+          (item) => item.callsign === message.callsign,
+        );
+        setSelectedCallsign(previousSelection ? previousSelection.callsign : null);
+        pushToast({
+          type: 'error',
+          message: `Failed to create ${message.callsign}: ${errorMessage}`,
+        });
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [pushToast],
+  );
+
+  const handleUpdate = useCallback(
+    async (message: EmergencyActionMessage) => {
+      const previousMessages = cloneMessages(messagesRef.current);
+      setIsSubmitting(true);
+      pushToast({ type: 'info', message: `Updating message ${message.callsign}…` });
+      setMessages((current) =>
+        current.map((item) =>
+          item.callsign === message.callsign ? { ...item, ...message } : item,
+        ),
+      );
+
+      try {
+        const updated = await updateEmergencyActionMessage(message);
+        if (!updated) {
+          setMessages(previousMessages);
+          pushToast({
+            type: 'error',
+            message: `${message.callsign} no longer exists on the server.`,
+          });
+          return;
+        }
+        setMessages((current) =>
+          current.map((item) =>
+            item.callsign === updated.callsign ? { ...item, ...updated } : item,
+          ),
+        );
+        pushToast({ type: 'success', message: `Gateway updated ${message.callsign}.` });
+      } catch (error) {
+        const errorMessage = extractApiErrorMessage(error);
+        setMessages(previousMessages);
+        pushToast({
+          type: 'error',
+          message: `Failed to update ${message.callsign}: ${errorMessage}`,
+        });
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [pushToast],
+  );
+
+  const handleSubmit = useCallback(
+    async (message: EmergencyActionMessage) => {
+      if (formMode === 'edit') {
+        await handleUpdate(message);
+      } else {
+        await handleCreate(message);
+      }
+    },
+    [formMode, handleCreate, handleUpdate],
+  );
+
+  const handleDelete = useCallback(() => {
+    if (!selectedMessage) {
+      return;
+    }
+    setDeleteDialogOpen(true);
+  }, [selectedMessage]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!selectedMessage) {
+      return;
+    }
+    const target = selectedMessage;
+    const previousMessages = cloneMessages(messagesRef.current);
+    setDeleteDialogOpen(false);
+    setMessages((current) => current.filter((item) => item.callsign !== target.callsign));
+    setSelectedCallsign(null);
+    pushToast({ type: 'info', message: `Deleting ${target.callsign}…` });
+
+    try {
+      await deleteEmergencyActionMessage(target.callsign);
+      pushToast({ type: 'success', message: `Deleted ${target.callsign}.` });
+    } catch (error) {
+      const errorMessage = extractApiErrorMessage(error);
+      setMessages(previousMessages);
+      setSelectedCallsign(target.callsign);
+      pushToast({
+        type: 'error',
+        message: `Failed to delete ${target.callsign}: ${errorMessage}`,
+      });
+    }
+  }, [pushToast, selectedMessage]);
+
+  return (
+    <section className="page-section">
+      <header className="page-header">
+        <h2>Emergency Action Messages</h2>
+        <p>
+          Review and dispatch emergency action messages across the mesh network.
+        </p>
+      </header>
+      <div className="page-card">
+        <p>
+          Manage emergency action message readiness, update unit statuses, and coordinate
+          communications through the FastAPI gateway.
+        </p>
+      </div>
+      {loading ? (
+        <div className="page-card">Loading messages…</div>
+      ) : loadError ? (
+        <div className="page-card page-error">{loadError}</div>
+      ) : (
+        <div className="page-grid">
+          <div className="page-card">
+            <MessagesTable
+              messages={messages}
+              selectedCallsign={selectedCallsign}
+              onSelect={handleSelectMessage}
+            />
+          </div>
+          <div className="page-card">
+            <MessageDetails
+              message={selectedMessage}
+              onEdit={() => setFormMode('edit')}
+              onDelete={handleDelete}
+            />
+          </div>
+          <div className="page-card">
+            <MessageForm
+              mode={formMode}
+              initialValue={formMode === 'edit' ? selectedMessage : null}
+              onSubmit={handleSubmit}
+              onReset={handleResetForm}
+              isSubmitting={isSubmitting}
+            />
+          </div>
+        </div>
+      )}
+      <DeleteMessageDialog
+        callsign={selectedMessage?.callsign ?? null}
+        isOpen={deleteDialogOpen}
+        onCancel={() => setDeleteDialogOpen(false)}
+        onConfirm={handleConfirmDelete}
+      />
+    </section>
+  );
+}

--- a/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/MessageDetails.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/MessageDetails.tsx
@@ -1,0 +1,65 @@
+import type { EmergencyActionMessage } from '../../lib/apiClient';
+
+interface MessageDetailsProps {
+  message: EmergencyActionMessage | null;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const FIELD_LABELS: Array<keyof EmergencyActionMessage> = [
+  'groupName',
+  'securityStatus',
+  'securityCapability',
+  'preparednessStatus',
+  'medicalStatus',
+  'mobilityStatus',
+  'commsStatus',
+  'commsMethod',
+];
+
+function formatFieldLabel(field: keyof EmergencyActionMessage): string {
+  return field
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+export function MessageDetails({
+  message,
+  onEdit,
+  onDelete,
+}: MessageDetailsProps): JSX.Element {
+  if (!message) {
+    return (
+      <div className="message-details-empty">
+        Select a message from the table to review its details.
+      </div>
+    );
+  }
+
+  return (
+    <div className="message-details">
+      <header className="message-details-header">
+        <div>
+          <h3>{message.callsign}</h3>
+          {message.groupName && <p className="message-details-subtitle">Group: {message.groupName}</p>}
+        </div>
+        <div className="message-details-actions">
+          <button type="button" onClick={onEdit} className="secondary-button">
+            Edit
+          </button>
+          <button type="button" onClick={onDelete} className="danger-button">
+            Delete
+          </button>
+        </div>
+      </header>
+      <dl className="page-definition-list">
+        {FIELD_LABELS.map((field) => (
+          <div key={field}>
+            <dt>{formatFieldLabel(field)}</dt>
+            <dd>{message[field] ?? '—'}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/MessageForm.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/MessageForm.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type { EAMStatus, EmergencyActionMessage } from '../../lib/apiClient';
+
+export type MessageFormMode = 'create' | 'edit';
+
+interface MessageFormProps {
+  mode: MessageFormMode;
+  initialValue: EmergencyActionMessage | null;
+  onSubmit: (message: EmergencyActionMessage) => Promise<void> | void;
+  onReset: () => void;
+  isSubmitting: boolean;
+}
+
+const STATUS_FIELDS: Array<keyof EmergencyActionMessage> = [
+  'securityStatus',
+  'securityCapability',
+  'preparednessStatus',
+  'medicalStatus',
+  'mobilityStatus',
+  'commsStatus',
+];
+
+const STATUS_OPTIONS: Array<EAMStatus | ''> = ['', 'Red', 'Yellow', 'Green'];
+
+interface FormState extends EmergencyActionMessage {}
+
+interface FormErrors {
+  callsign?: string;
+}
+
+function buildInitialState(value: EmergencyActionMessage | null): FormState {
+  return {
+    callsign: value?.callsign ?? '',
+    groupName: value?.groupName ?? '',
+    securityStatus: value?.securityStatus ?? null,
+    securityCapability: value?.securityCapability ?? null,
+    preparednessStatus: value?.preparednessStatus ?? null,
+    medicalStatus: value?.medicalStatus ?? null,
+    mobilityStatus: value?.mobilityStatus ?? null,
+    commsStatus: value?.commsStatus ?? null,
+    commsMethod: value?.commsMethod ?? '',
+  };
+}
+
+export function MessageForm({
+  mode,
+  initialValue,
+  onSubmit,
+  onReset,
+  isSubmitting,
+}: MessageFormProps): JSX.Element {
+  const [state, setState] = useState<FormState>(() => buildInitialState(initialValue));
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  useEffect(() => {
+    setState(buildInitialState(initialValue));
+    setErrors({});
+  }, [initialValue]);
+
+  const isEditMode = mode === 'edit';
+  const statusLegend = useMemo(
+    () =>
+      STATUS_FIELDS.map((field) => ({
+        field,
+        label: field.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase()),
+      })),
+    [],
+  );
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors: FormErrors = {};
+    if (!state.callsign.trim()) {
+      nextErrors.callsign = 'Callsign is required.';
+    }
+
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    await onSubmit({
+      ...state,
+      callsign: state.callsign.trim(),
+      groupName: state.groupName?.trim() || undefined,
+      commsMethod: state.commsMethod?.trim() || undefined,
+    });
+  };
+
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = event.target;
+    setState((current) => ({
+      ...current,
+      [name]: value === '' ? '' : value,
+    }));
+  };
+
+  const handleStatusChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+    field: keyof EmergencyActionMessage,
+  ) => {
+    const value = event.target.value as EAMStatus | '';
+    setState((current) => ({
+      ...current,
+      [field]: value === '' ? null : value,
+    }));
+  };
+
+  return (
+    <form className="message-form" onSubmit={handleSubmit}>
+      <header className="message-form-header">
+        <h3>{isEditMode ? 'Update message' : 'Create a new message'}</h3>
+        <button type="button" className="secondary-button" onClick={onReset}>
+          New message
+        </button>
+      </header>
+      <div className="form-field">
+        <label htmlFor="eam-callsign">Callsign</label>
+        <input
+          id="eam-callsign"
+          name="callsign"
+          type="text"
+          value={state.callsign}
+          onChange={handleInputChange}
+          disabled={isEditMode}
+          aria-invalid={errors.callsign ? 'true' : 'false'}
+        />
+        {errors.callsign && <p className="field-error">{errors.callsign}</p>}
+      </div>
+      <div className="form-field">
+        <label htmlFor="eam-group-name">Group name</label>
+        <input
+          id="eam-group-name"
+          name="groupName"
+          type="text"
+          value={state.groupName ?? ''}
+          onChange={handleInputChange}
+        />
+      </div>
+      {statusLegend.map(({ field, label }) => (
+        <div className="form-field" key={field}>
+          <label htmlFor={`eam-${field}`}>{label}</label>
+          <select
+            id={`eam-${field}`}
+            value={state[field] ?? ''}
+            onChange={(event) => handleStatusChange(event, field)}
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option || 'empty'} value={option}>
+                {option || 'Not specified'}
+              </option>
+            ))}
+          </select>
+        </div>
+      ))}
+      <div className="form-field">
+        <label htmlFor="eam-comms-method">Comms method</label>
+        <input
+          id="eam-comms-method"
+          name="commsMethod"
+          type="text"
+          value={state.commsMethod ?? ''}
+          onChange={handleInputChange}
+        />
+      </div>
+      <button type="submit" className="primary-button" disabled={isSubmitting}>
+        {isEditMode ? 'Save changes' : 'Create message'}
+      </button>
+    </form>
+  );
+}

--- a/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/MessagesTable.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/MessagesTable.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react';
+
+import type { EAMStatus, EmergencyActionMessage } from '../../lib/apiClient';
+
+type StatusFilter = 'all' | EAMStatus;
+
+interface MessagesTableProps {
+  messages: EmergencyActionMessage[];
+  selectedCallsign: string | null;
+  onSelect: (callsign: string) => void;
+}
+
+const STATUS_FILTER_OPTIONS: StatusFilter[] = ['all', 'Red', 'Yellow', 'Green'];
+
+function normaliseText(value: string | undefined | null): string {
+  return (value ?? '').toLowerCase();
+}
+
+export function MessagesTable({
+  messages,
+  selectedCallsign,
+  onSelect,
+}: MessagesTableProps): JSX.Element {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  const filteredMessages = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return messages.filter((message) => {
+      const matchesTerm = term
+        ? normaliseText(message.callsign).includes(term) ||
+          normaliseText(message.groupName).includes(term)
+        : true;
+      const matchesStatus =
+        statusFilter === 'all' || message.securityStatus === statusFilter;
+      return matchesTerm && matchesStatus;
+    });
+  }, [messages, searchTerm, statusFilter]);
+
+  return (
+    <div className="messages-table" aria-live="polite">
+      <div className="messages-table-controls">
+        <label className="field-label" htmlFor="eam-search-input">
+          Search
+        </label>
+        <input
+          id="eam-search-input"
+          type="search"
+          value={searchTerm}
+          placeholder="Search by callsign or group"
+          onChange={(event) => setSearchTerm(event.target.value)}
+        />
+        <label className="field-label" htmlFor="eam-status-filter">
+          Security status
+        </label>
+        <select
+          id="eam-status-filter"
+          value={statusFilter}
+          onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
+        >
+          {STATUS_FILTER_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {option === 'all' ? 'All statuses' : option}
+            </option>
+          ))}
+        </select>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Callsign</th>
+            <th scope="col">Group</th>
+            <th scope="col">Security</th>
+            <th scope="col">Comms</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filteredMessages.length === 0 ? (
+            <tr>
+              <td colSpan={4} className="messages-table-empty">
+                No messages match the current filters.
+              </td>
+            </tr>
+          ) : (
+            filteredMessages.map((message) => {
+              const isSelected = message.callsign === selectedCallsign;
+              return (
+                <tr
+                  key={message.callsign}
+                  className={isSelected ? 'messages-table-row-selected' : ''}
+                  onClick={() => onSelect(message.callsign)}
+                  tabIndex={0}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onSelect(message.callsign);
+                    }
+                  }}
+                  aria-selected={isSelected}
+                >
+                  <td>{message.callsign}</td>
+                  <td>{message.groupName ?? '—'}</td>
+                  <td>{message.securityStatus ?? '—'}</td>
+                  <td>{message.commsStatus ?? '—'}</td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/__tests__/EmergencyActionMessagesPage.test.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/EmergencyActionMessages/__tests__/EmergencyActionMessagesPage.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../lib/apiClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/apiClient')>();
+  return {
+    ...actual,
+    listEmergencyActionMessages: vi.fn(),
+    createEmergencyActionMessage: vi.fn(),
+    updateEmergencyActionMessage: vi.fn(),
+    deleteEmergencyActionMessage: vi.fn(),
+    extractApiErrorMessage: vi.fn((error: unknown) => {
+      if (error instanceof Error) {
+        return error.message;
+      }
+      return 'error';
+    }),
+  };
+});
+
+import { ToastProvider } from '../../../components/toast';
+import { EmergencyActionMessagesPage } from '../EmergencyActionMessagesPage';
+import {
+  createEmergencyActionMessage,
+  deleteEmergencyActionMessage,
+  listEmergencyActionMessages,
+  updateEmergencyActionMessage,
+  type EmergencyActionMessage,
+} from '../../../lib/apiClient';
+
+const listMock = vi.mocked(listEmergencyActionMessages);
+const createMock = vi.mocked(createEmergencyActionMessage);
+const updateMock = vi.mocked(updateEmergencyActionMessage);
+const deleteMock = vi.mocked(deleteEmergencyActionMessage);
+
+function renderPage(): void {
+  render(
+    <ToastProvider>
+      <EmergencyActionMessagesPage />
+    </ToastProvider>,
+  );
+}
+
+describe('EmergencyActionMessagesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders messages and supports creating and updating records', async () => {
+    const initialMessages: EmergencyActionMessage[] = [
+      {
+        callsign: 'Alpha-1',
+        groupName: 'Alpha',
+        securityStatus: 'Green',
+      },
+      {
+        callsign: 'Bravo-2',
+        groupName: 'Bravo',
+        securityStatus: 'Yellow',
+      },
+    ];
+    listMock.mockResolvedValue(initialMessages);
+    createMock.mockResolvedValue({
+      callsign: 'Charlie-3',
+      groupName: 'Charlie',
+      securityStatus: 'Red',
+    });
+    updateMock.mockResolvedValue({
+      callsign: 'Alpha-1',
+      groupName: 'Alpha Updated',
+      securityStatus: 'Green',
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Alpha-1').length).toBeGreaterThan(0);
+      expect(screen.getByText('Bravo-2')).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'New message' }));
+    const createButton = await screen.findByRole('button', { name: 'Create message' });
+    await user.type(screen.getByLabelText('Callsign'), 'Charlie-3');
+    await user.type(screen.getByLabelText('Group name'), 'Charlie');
+    await user.selectOptions(screen.getByLabelText('Security Status'), 'Red');
+    await user.click(createButton);
+
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalledTimes(1);
+    });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ callsign: 'Charlie-3', securityStatus: 'Red' }),
+    );
+    expect(screen.getAllByText('Charlie-3').length).toBeGreaterThan(0);
+
+    await user.click(screen.getByText('Alpha-1'));
+    const groupInput = screen.getByLabelText('Group name');
+    await user.clear(groupInput);
+    await user.type(groupInput, 'Alpha Updated');
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledTimes(1);
+    });
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ callsign: 'Alpha-1', groupName: 'Alpha Updated' }),
+    );
+    expect(screen.getAllByText('Alpha Updated').length).toBeGreaterThan(0);
+  });
+
+  it('shows validation errors when required fields are missing', async () => {
+    listMock.mockResolvedValue([]);
+
+    renderPage();
+
+    const user = userEvent.setup();
+    const submitButton = await screen.findByRole('button', { name: 'Create message' });
+    await user.click(submitButton);
+
+    expect(await screen.findByText('Callsign is required.')).toBeInTheDocument();
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('confirms deletion before removing a message', async () => {
+    const message: EmergencyActionMessage = {
+      callsign: 'Alpha-1',
+      groupName: 'Alpha',
+      securityStatus: 'Green',
+    };
+    listMock.mockResolvedValue([message]);
+    deleteMock.mockResolvedValue({ status: 'deleted', callsign: 'Alpha-1' });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Alpha-1').length).toBeGreaterThan(0);
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByText((content) =>
+        content.includes('Are you sure you want to delete the message for'),
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(deleteMock).toHaveBeenCalledWith('Alpha-1');
+      expect(screen.queryByText('Alpha-1')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/examples/EmergencyManagement/webui/src/router/index.tsx
+++ b/examples/EmergencyManagement/webui/src/router/index.tsx
@@ -2,7 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 
 import { Layout } from '../components/layout/Layout';
 import { DashboardPage } from '../pages/DashboardPage';
-import { EmergencyActionMessagesPage } from '../pages/EmergencyActionMessagesPage';
+import { EmergencyActionMessagesPage } from '../pages/EmergencyActionMessages/EmergencyActionMessagesPage';
 import { EventsPage } from '../pages/EventsPage';
 
 export const router = createBrowserRouter([

--- a/examples/EmergencyManagement/webui/src/setupTests.ts
+++ b/examples/EmergencyManagement/webui/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/examples/EmergencyManagement/webui/vite.config.ts
+++ b/examples/EmergencyManagement/webui/vite.config.ts
@@ -1,7 +1,12 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    css: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add a typed axios client for emergency action message endpoints and wrap the app with toast notifications
- build the emergency action messages page with table filters, detail view, editable form, and delete confirmation hooked to the FastAPI gateway
- introduce Vitest with React Testing Library coverage plus supporting styles and documentation updates

## Testing
- npm run lint
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d2d9f9102883258c301e488ee3d39a