### PR TITLE
Announce service identity via destination API

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -65,3 +65,5 @@
 - [x] Build Emergency Action Messages web UI with CRUD flows, optimistic toasts, and
   Vitest coverage. (2025-09-23)
 
+- [x] Ensure EmergencyManagement server announces its identity using the Reticulum Destination API. (2025-09-25)
+

--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -35,7 +35,7 @@ EXAMPLE_IDENTITY_HASH = (
     "761dfb354cfe5a3c9d8f5c4465b6c7f5"
 )
 PROMPT_MESSAGE = (
-    "Server Identity Hash 32  characters, e.g. "
+    "Server Identity Hash (32 hexadecimal characters, e.g. "
     f"{EXAMPLE_IDENTITY_HASH}): "
 )
 CONFIG_PATH = Path(__file__).with_name(CONFIG_FILENAME)

--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -50,7 +50,7 @@ class LXMFClient:
         """Announce this client's identity on the Reticulum network."""
 
         try:
-            self.router.announce(self.source_identity.hash)
+            self.source_identity.announce()
             logger.info(
                 "Client identity announced: %s",
                 RNS.prettyhexrep(self.source_identity.hash),

--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -410,7 +410,7 @@ class LXMFService:
     def announce(self):
         """Announce this service's identity (make its address known on the network)."""
         try:
-            self.router.announce(self.source_identity.hash)
+            self.source_identity.announce()
             logger.info(
                 "Service identity announced: %s",
                 RNS.prettyhexrep(self.source_identity.hash),

--- a/tests/test_client_extra.py
+++ b/tests/test_client_extra.py
@@ -159,7 +159,8 @@ async def test_send_command_dict_payload(monkeypatch):
 def test_client_announce(monkeypatch):
     cli = client_module.LXMFClient.__new__(client_module.LXMFClient)
     cli.router = SimpleNamespace(announce=Mock())
-    cli.source_identity = SimpleNamespace(hash=b"\x01")
+    ann_mock = Mock()
+    cli.source_identity = SimpleNamespace(hash=b"\x01", announce=ann_mock)
     monkeypatch.setattr(client_module.RNS, "prettyhexrep", lambda data: "01")
     cli.announce()
-    cli.router.announce.assert_called_once_with(cli.source_identity.hash)
+    ann_mock.assert_called_once_with()

--- a/tests/test_service_extra.py
+++ b/tests/test_service_extra.py
@@ -105,12 +105,12 @@ async def test_send_lxmf_uses_router(monkeypatch):
 async def test_announce_logs(monkeypatch):
     svc = service_module.LXMFService.__new__(service_module.LXMFService)
     ann_mock = Mock()
-    svc.router = SimpleNamespace(announce=ann_mock)
-    svc.source_identity = SimpleNamespace(hash=b"x")
+    svc.router = SimpleNamespace(announce=Mock())
+    svc.source_identity = SimpleNamespace(hash=b"x", announce=ann_mock)
     monkeypatch.setattr(service_module.RNS, "prettyhexrep", lambda x: "x")
     monkeypatch.setattr(service_module.RNS, "log", lambda *a, **k: None)
     svc.announce()
-    ann_mock.assert_called_once_with(svc.source_identity.hash)
+    ann_mock.assert_called_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update the LXMF service and client announce helpers to call the destination announce API so identity details are included in broadcasts
- refresh emergency client prompt copy to clarify the server identity requires a hexadecimal string
- align unit tests with the new announce behaviour and document the completed task in TASK.md

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2eebd328c832598a1a9a96baccaf0