### PR TITLE
Fix emergency management test imports

### DIFF
--- a/tests/examples/emergency_management/test_web_gateway.py
+++ b/tests/examples/emergency_management/test_web_gateway.py
@@ -15,11 +15,15 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from examples.EmergencyManagement.Server.models_emergency import (
-    EmergencyActionMessage,
-    Event,
+_models_module = importlib.import_module(
+    "examples.EmergencyManagement.Server.models_emergency"
 )
-from examples.EmergencyManagement.client.client import LXMFClient as RealLXMFClient
+EmergencyActionMessage = _models_module.EmergencyActionMessage
+Event = _models_module.Event
+
+RealLXMFClient = importlib.import_module(
+    "examples.EmergencyManagement.client.client"
+).LXMFClient
 from reticulum_openapi.codec_msgpack import to_canonical_bytes
 
 


### PR DESCRIPTION
## Summary
- load emergency management models and client via importlib to avoid top-level import ordering issues in tests

## Testing
- pytest tests/examples/emergency_management/test_web_gateway.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68d2f05c3d608325ae29af7d37d92aec