### PR TITLE
Resolve lint issues in tests

### DIFF
--- a/tests/examples/emergency_management/test_web_gateway.py
+++ b/tests/examples/emergency_management/test_web_gateway.py
@@ -3,27 +3,17 @@
 from __future__ import annotations
 
 import importlib
-import sys
-from pathlib import Path
 from typing import List
 from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-_models_module = importlib.import_module(
-    "examples.EmergencyManagement.Server.models_emergency"
+from examples.EmergencyManagement.Server.models_emergency import (
+    EmergencyActionMessage,
+    Event,
 )
-EmergencyActionMessage = _models_module.EmergencyActionMessage
-Event = _models_module.Event
-
-RealLXMFClient = importlib.import_module(
-    "examples.EmergencyManagement.client.client"
-).LXMFClient
+from examples.EmergencyManagement.client.client import LXMFClient as RealLXMFClient
 from reticulum_openapi.codec_msgpack import to_canonical_bytes
 
 

--- a/tests/test_client_extra.py
+++ b/tests/test_client_extra.py
@@ -33,9 +33,6 @@ async def test_client_init(monkeypatch):
         def handle_outbound(self, msg):
             pass
 
-        def handle_outbound(self, msg):
-            pass
-
     class DummyDestination:
         OUT = object()
         SINGLE = object()
@@ -175,7 +172,6 @@ def test_client_announce(monkeypatch):
     cli.source_identity = SimpleNamespace(hash=b"\x01", announce=ann_mock)
     monkeypatch.setattr(client_module.RNS, "prettyhexrep", lambda data: "01")
     cli.announce()
-    
     cli.router.announce.assert_called_once_with(cli.source_identity.hash)
 
 
@@ -258,4 +254,3 @@ async def test_listen_for_announces_prints(monkeypatch):
     assert output
     assert "<aabb>" in output[0]
     assert "<0102>" in output[0]
-


### PR DESCRIPTION
## Summary
- replace runtime import hacks in the Emergency Management gateway tests with normal package imports
- remove duplicated method definition and trailing whitespace in the LXMF client extra tests to satisfy flake8

## Testing
- flake8 tests/examples/emergency_management/test_web_gateway.py tests/test_client_extra.py

------
https://chatgpt.com/codex/tasks/task_e_68d304abdd248325bf393db17c5a30c2