### PR TITLE
Fix LXMF announce handler aspect filter type

### DIFF
--- a/reticulum_openapi/client.py
+++ b/reticulum_openapi/client.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class _AnnounceHandler:
     """Adapter that forwards Reticulum announces into an asyncio queue."""
 
-    aspect_filter = ["lxmf"]
+    aspect_filter = "lxmf"
     receive_path_responses = False
 
     def __init__(self, loop: asyncio.AbstractEventLoop, queue: asyncio.Queue):
@@ -79,6 +79,8 @@ class LXMFClient:
         """Announce this client's identity on the Reticulum network."""
 
         try:
+            if hasattr(self.router, "announce"):
+                self.router.announce(self.source_identity.hash)
             self.source_identity.announce()
             logger.info(
                 "Client identity announced: %s",

--- a/tests/test_client_extra.py
+++ b/tests/test_client_extra.py
@@ -65,7 +65,7 @@ async def test_client_init(monkeypatch):
     assert isinstance(cli.router, DummyRouter)
     assert cli._futures == {}
     assert isinstance(cli._announce_queue, asyncio.Queue)
-    assert register_calls["handler"].aspect_filter == ["lxmf"]
+    assert register_calls["handler"].aspect_filter == "lxmf"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- set the LXMF announce handler aspect filter to the string value expected by Reticulum
- announce through the LXMF router before emitting the client identity hash
- align the client initialisation test with the announce handler configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3061fb4548325a2e1ca4def825830