### PR TITLE
Fix EmergencyManagement package imports

### DIFF
--- a/examples/EmergencyManagement/Server/__init__.py
+++ b/examples/EmergencyManagement/Server/__init__.py
@@ -1,0 +1,3 @@
+"""Server components for the Emergency Management example."""
+
+__all__ = []

--- a/examples/EmergencyManagement/__init__.py
+++ b/examples/EmergencyManagement/__init__.py
@@ -1,0 +1,25 @@
+"""Emergency Management example package."""
+
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import Server as _ServerPackage  # noqa: F401
+    from . import client as _ClientPackage  # noqa: F401
+
+
+def load_submodule(name: str) -> ModuleType:
+    """Import a submodule from the Emergency Management package.
+
+    Args:
+        name (str): The dotted path suffix of the submodule to load.
+
+    Returns:
+        ModuleType: The imported submodule.
+    """
+
+    return import_module(f"{__name__}.{name}")
+
+
+__all__ = ["load_submodule"]

--- a/examples/EmergencyManagement/client/__init__.py
+++ b/examples/EmergencyManagement/client/__init__.py
@@ -1,0 +1,5 @@
+"""Client utilities for the Emergency Management example."""
+
+from .client import LXMFClient
+
+__all__ = ["LXMFClient"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ dev = [
     "pytest-asyncio",
     "flake8"
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
## Summary
- add package initialisers for the EmergencyManagement example directories so pytest can import modules
- configure pytest to include the repository root on sys.path for collection

## Testing
- pytest tests/examples/emergency_management/test_web_gateway.py

------
https://chatgpt.com/codex/tasks/task_e_68d3077e37c0832580bcffce393876ea