### PR TITLE
Ensure EmergencyManagement client can load stdlib pkgutil when run from its folder

### DIFF
--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -1,8 +1,41 @@
+import sys
+from typing import Optional
+
+
+def _ensure_standard_library_on_path() -> None:
+    """Ensure CPython standard library directories are available."""
+
+    version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    zipped = f"python{sys.version_info.major}{sys.version_info.minor}.zip"
+    base_dirs = {sys.base_prefix, sys.exec_prefix, sys.prefix}
+    lib_dir_names = ["lib", "Lib"]
+
+    for base_dir in base_dirs:
+        if not base_dir:
+            continue
+
+        for lib_dir_name in lib_dir_names:
+            lib_dir = f"{base_dir}/{lib_dir_name}"
+            candidates = [
+                f"{lib_dir}/{zipped}",
+                f"{lib_dir}/{version}",
+                f"{lib_dir}/{version}/lib-dynload",
+                f"{lib_dir}/{version}/site-packages",
+                f"{lib_dir}/{version}/dist-packages",
+                f"{lib_dir}/site-packages",
+                f"{lib_dir}/dist-packages",
+            ]
+
+            for candidate in candidates:
+                if candidate and candidate not in sys.path:
+                    sys.path.append(candidate)
+
+
+_ensure_standard_library_on_path()
+
 import asyncio
 import json
-import sys
 from pathlib import Path
-from typing import Optional
 
 # Reason: Allow running the example from the client directory by ensuring
 # the project root is on sys.path so that absolute imports resolve.

--- a/examples/EmergencyManagement/client/pkgutil.py
+++ b/examples/EmergencyManagement/client/pkgutil.py
@@ -1,0 +1,47 @@
+"""Expose the standard library ``pkgutil`` module when ``sys.path`` is limited."""
+
+import sys
+
+
+def _load_stdlib_pkgutil():
+    """Return the real standard library implementation of :mod:`pkgutil`."""
+
+    version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    candidate_templates = [
+        "{base}/{lib}/{version}/pkgutil.py",
+        "{base}/{lib}/pkgutil.py",
+    ]
+
+    for base_dir in {sys.base_prefix, sys.exec_prefix, sys.prefix}:
+        if not base_dir:
+            continue
+
+        for lib_dir in ("lib", "Lib"):
+            for template in candidate_templates:
+                candidate = template.format(
+                    base=base_dir,
+                    lib=lib_dir,
+                    version=version,
+                )
+
+                try:
+                    with open(candidate, "r", encoding="utf-8") as handle:
+                        source = handle.read()
+                except (FileNotFoundError, OSError):
+                    continue
+
+                module = type(sys)("pkgutil")
+                module.__file__ = candidate
+                exec(compile(source, candidate, "exec"), module.__dict__)
+                return module
+
+    raise ModuleNotFoundError("Unable to locate standard library pkgutil")
+
+
+_real_pkgutil = _load_stdlib_pkgutil()
+
+sys.modules.setdefault("pkgutil", _real_pkgutil)
+
+globals().update(_real_pkgutil.__dict__)
+
+__all__ = getattr(_real_pkgutil, "__all__", [])


### PR DESCRIPTION
## Summary
- ensure the EmergencyManagement client script restores standard library directories before performing project imports
- add a pkgutil bootstrap module in the client example so runpy can resolve the stdlib implementation when sys.path is restricted

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3095549fc83259b3b4e103a150e77