### PR TITLE
Fix EmergencyManagement client announce visibility

### DIFF
--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -74,6 +74,14 @@ PROMPT_MESSAGE = (
 CONFIG_PATH = Path(__file__).with_name(CONFIG_FILENAME)
 
 
+async def _prompt_for_server_identity() -> str:
+    """Prompt the user for a server identity hash without blocking the loop."""
+
+    loop = asyncio.get_running_loop()
+    response = await loop.run_in_executor(None, input, PROMPT_MESSAGE)
+    return response.strip()
+
+
 def load_client_config(config_path: Optional[Path] = None) -> dict:
     """Return configuration data from JSON or an empty dict when unavailable."""
 
@@ -168,7 +176,7 @@ async def main():
         else:
             print(f"Using server identity hash from {CONFIG_PATH}")
     if server_id is None:
-        server_id = input(PROMPT_MESSAGE).strip()
+        server_id = await _prompt_for_server_identity()
 
     eam = EmergencyActionMessage(
         callsign="Bravo1",

--- a/tests/examples/emergency_management/test_client_emergency.py
+++ b/tests/examples/emergency_management/test_client_emergency.py
@@ -1,0 +1,48 @@
+"""Tests for the interactive Emergency Management client helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+
+import pytest
+
+
+from examples.EmergencyManagement.client import client_emergency
+
+
+class _DummyLoop:
+    """Test double that records executor invocations."""
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def run_in_executor(self, executor, func, *args):
+        """Record calls and invoke the provided function synchronously."""
+
+        self.calls.append((executor, func, args))
+        return func(*args)
+
+
+@pytest.mark.asyncio
+async def test_prompt_for_server_identity_uses_executor_and_strips(monkeypatch):
+    """The server identity prompt should run via an executor and trim whitespace."""
+
+    dummy_loop = _DummyLoop()
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: dummy_loop)
+
+    prompts = {}
+
+    def fake_input(prompt: str) -> str:
+        prompts["value"] = prompt
+        return " 0123456789ABCDEF "
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    response = await client_emergency._prompt_for_server_identity()
+
+    assert response == "0123456789ABCDEF"
+    assert dummy_loop.calls == [
+        (None, fake_input, (client_emergency.PROMPT_MESSAGE,)),
+    ]
+    assert prompts["value"] == client_emergency.PROMPT_MESSAGE


### PR DESCRIPTION
## Summary
- run the EmergencyManagement client identity prompt through an executor so background announce logging remains active
- add an asynchronous unit test covering the non-blocking prompt helper behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d30cb402548325a02e7a5c4aa9d9fe