### PR TITLE
Add gateway status endpoint for Emergency Management UI

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -66,4 +66,5 @@
   coverage for messages/events with automated Vitest suites.
 - [x] Ensure EmergencyManagement server announces its identity using the Reticulum Destination API. (2025-09-25)
 - [x] Add DestinationAnnouncer helper for LXMF services to broadcast identities.
+- [x] Expose gateway status endpoint for the Emergency Management web UI. (2025-09-23)
 

--- a/tests/examples/emergency_management/test_web_gateway.py
+++ b/tests/examples/emergency_management/test_web_gateway.py
@@ -179,3 +179,17 @@ def test_invalid_server_identity_returns_422(gateway_app) -> None:
     )
 
     assert response.status_code == 422
+
+
+def test_gateway_status_returns_version_and_uptime(gateway_app) -> None:
+    """The root endpoint should expose version metadata and uptime."""
+
+    module, client, _stub = gateway_app
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["version"] == module._GATEWAY_VERSION
+    assert isinstance(payload["uptime"], str)
+    assert payload["uptime"].count(":") == 2


### PR DESCRIPTION
## Summary
- add a root FastAPI endpoint that reports the gateway version and uptime for the Emergency Management UI
- derive the version from package metadata with a development fallback and expose a formatted uptime helper
- cover the new status route with tests and record the completed task in `TASK.md`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31071715c8325b0e0782967e0e11e