### PR TITLE
Fix EmergencyManagement client identity handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 examples/EmergencyManagement/emergency.db
+examples/EmergencyManagement/client/.reticulum_client/

--- a/examples/EmergencyManagement/client/client_config.json
+++ b/examples/EmergencyManagement/client/client_config.json
@@ -1,7 +1,7 @@
 {
-  "server_identity_hash": "ab930a8d1c600650710c1a503d5880dc",
+  "server_identity_hash": "",
   "client_display_name": "EmergencyClient",
-  "request_timeout_seconds": 300.0,
+  "request_timeout_seconds": 30,
   "lxmf_config_path": null,
   "lxmf_storage_path": null
 }


### PR DESCRIPTION
## Summary
- ensure the EmergencyManagement client provisions its own Reticulum identity and storage directories instead of reusing the server configuration
- harden LXMF response handling so the service can normalise reply destinations and fall back gracefully when the transport identity is unknown
- ignore generated Reticulum state files and reset the sample client config to prompt for the server identity hash

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d30db26d0483259a2a1880e1ceb5cc