### PR TITLE
Add SSE notifications bridge for LXMF

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -68,3 +68,6 @@
 - [x] Add DestinationAnnouncer helper for LXMF services to broadcast identities.
 - [x] Expose gateway status endpoint for the Emergency Management web UI. (2025-09-23)
 
+## 2025-09-28
+- [x] Stream EmergencyService notifications to FastAPI subscribers via SSE.
+

--- a/reticulum_openapi/api/__init__.py
+++ b/reticulum_openapi/api/__init__.py
@@ -1,0 +1,15 @@
+"""FastAPI helper routers for Reticulum OpenAPI."""
+
+from .notifications import (
+    NotificationHub,
+    attach_client_notifications,
+    notification_hub,
+    router,
+)
+
+__all__ = [
+    "NotificationHub",
+    "attach_client_notifications",
+    "notification_hub",
+    "router",
+]

--- a/reticulum_openapi/api/notifications.py
+++ b/reticulum_openapi/api/notifications.py
@@ -1,0 +1,158 @@
+"""Utilities for broadcasting LXMF notifications over FastAPI."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import zlib
+from dataclasses import asdict
+from dataclasses import is_dataclass
+from typing import Any
+from typing import AsyncGenerator
+from typing import Awaitable
+from typing import Callable
+from typing import Dict
+from typing import Set
+
+from fastapi import APIRouter
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+
+from ..client import LXMFClient
+from ..codec_msgpack import from_bytes as msgpack_from_bytes
+
+
+class NotificationHub:
+    """Manage SSE subscribers and broadcast notification payloads."""
+
+    def __init__(self, queue_size: int = 32):
+        self._queue_size = queue_size
+        self._lock = asyncio.Lock()
+        self._subscribers: Set[asyncio.Queue[str]] = set()
+
+    async def add_subscriber(self) -> asyncio.Queue[str]:
+        """Register a new subscriber queue for notification delivery."""
+
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self._queue_size)
+        async with self._lock:
+            self._subscribers.add(queue)
+        return queue
+
+    async def remove_subscriber(self, queue: asyncio.Queue[str]) -> None:
+        """Remove a subscriber queue from the broadcast list."""
+
+        async with self._lock:
+            self._subscribers.discard(queue)
+
+    async def broadcast(self, message: Dict[str, Any]) -> None:
+        """Publish a notification to all active subscribers."""
+
+        payload = json.dumps(message)
+        async with self._lock:
+            subscribers = list(self._subscribers)
+        for queue in subscribers:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                try:
+                    _ = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+                try:
+                    queue.put_nowait(payload)
+                except asyncio.QueueFull:
+                    # Skip unresponsive subscriber
+                    continue
+
+    async def reset(self) -> None:
+        """Remove all known subscribers."""
+
+        async with self._lock:
+            self._subscribers.clear()
+
+
+notification_hub = NotificationHub()
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+def _normalise_payload(value: Any) -> Any:
+    """Convert dataclasses and binary blobs into JSON-safe structures."""
+
+    if is_dataclass(value):
+        return _normalise_payload(asdict(value))
+    if isinstance(value, dict):
+        return {str(key): _normalise_payload(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalise_payload(item) for item in value]
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return base64.b64encode(bytes(value)).decode("ascii")
+    return value
+
+
+def _decode_payload(payload: bytes) -> Dict[str, Any]:
+    """Decode LXMF payloads into JSON serialisable structures."""
+
+    if not payload:
+        return {"payload": None, "payload_raw": ""}
+
+    encoded = base64.b64encode(payload).decode("ascii")
+    try:
+        decoded = msgpack_from_bytes(payload)
+        normalised = _normalise_payload(decoded)
+        return {"payload": normalised, "payload_raw": encoded}
+    except Exception:
+        try:
+            json_bytes = zlib.decompress(payload)
+        except zlib.error:
+            json_bytes = payload
+        try:
+            normalised = json.loads(json_bytes.decode("utf-8"))
+            return {"payload": normalised, "payload_raw": encoded}
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return {"payload": None, "payload_raw": encoded}
+
+
+async def _event_stream(
+    request: Request, queue: asyncio.Queue[str]
+) -> AsyncGenerator[str, None]:
+    """Yield Server-Sent Events until the client disconnects."""
+
+    try:
+        while True:
+            if await request.is_disconnected():
+                break
+            try:
+                message = await asyncio.wait_for(queue.get(), timeout=1.0)
+            except asyncio.TimeoutError:
+                continue
+            yield f"data: {message}\n\n"
+    finally:
+        await notification_hub.remove_subscriber(queue)
+
+
+@router.get("/stream", summary="Subscribe to EmergencyService notifications")
+async def stream_notifications(request: Request) -> StreamingResponse:
+    """Stream notifications to connected clients using SSE."""
+
+    queue = await notification_hub.add_subscriber()
+    generator = _event_stream(request, queue)
+    return StreamingResponse(generator, media_type="text/event-stream")
+
+
+async def attach_client_notifications(
+    client: LXMFClient,
+) -> Callable[[], Awaitable[None]]:
+    """Forward unsolicited LXMF messages to the notification hub."""
+
+    async def _listener(title: str, payload: bytes) -> None:
+        decoded = _decode_payload(payload)
+        message = {"title": title, **decoded}
+        await notification_hub.broadcast(message)
+
+    unsubscribe = await client.add_notification_listener(_listener)
+
+    async def _detach() -> None:
+        await unsubscribe()
+
+    return _detach

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for FastAPI integration components."""

--- a/tests/api/test_notifications.py
+++ b/tests/api/test_notifications.py
@@ -1,0 +1,119 @@
+"""Tests for the notifications streaming endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from reticulum_openapi import client as client_module
+from reticulum_openapi.api import notifications
+from reticulum_openapi.codec_msgpack import to_canonical_bytes
+
+
+async def _create_stub_client() -> client_module.LXMFClient:
+    """Return a partially initialised LXMF client suitable for tests."""
+
+    loop = asyncio.get_running_loop()
+    client = client_module.LXMFClient.__new__(client_module.LXMFClient)
+    client._loop = loop
+    client._futures = {}
+    client._notification_listeners = set()
+    client._listener_lock = asyncio.Lock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_unsolicited_message_broadcasts_to_subscribers():
+    """LXMF callbacks should forward payloads to notification subscribers."""
+
+    await notifications.notification_hub.reset()
+    queue = await notifications.notification_hub.add_subscriber()
+    client = await _create_stub_client()
+    unsubscribe = await notifications.attach_client_notifications(client)
+
+    payload = to_canonical_bytes({"event": "test", "status": "ok"})
+    message = SimpleNamespace(title="EmergencyUpdate", content=payload)
+    client._callback(message)
+    raw = await asyncio.wait_for(queue.get(), timeout=1.0)
+    data = json.loads(raw)
+
+    await unsubscribe()
+    await notifications.notification_hub.remove_subscriber(queue)
+
+    assert data["title"] == "EmergencyUpdate"
+    assert data["payload"] == {"event": "test", "status": "ok"}
+    assert data["payload_raw"]
+
+
+@pytest.mark.asyncio
+async def test_binary_payload_falls_back_to_base64():
+    """Binary payloads should include a base64 representation for clients."""
+
+    await notifications.notification_hub.reset()
+    queue = await notifications.notification_hub.add_subscriber()
+    client = await _create_stub_client()
+    unsubscribe = await notifications.attach_client_notifications(client)
+
+    message = SimpleNamespace(title="EmergencyBinary", content=b"\xff\x00")
+    client._callback(message)
+    raw = await asyncio.wait_for(queue.get(), timeout=1.0)
+    data = json.loads(raw)
+
+    await unsubscribe()
+    await notifications.notification_hub.remove_subscriber(queue)
+
+    assert data["title"] == "EmergencyBinary"
+    assert data["payload"] is None
+    assert data["payload_raw"] == "/wA="
+
+
+@pytest.mark.asyncio
+async def test_event_stream_yields_sse_payloads():
+    """The SSE generator should yield formatted data lines."""
+
+    await notifications.notification_hub.reset()
+    queue = await notifications.notification_hub.add_subscriber()
+
+    disconnect = asyncio.Event()
+
+    class StubRequest:
+        async def is_disconnected(self) -> bool:
+            return disconnect.is_set()
+
+    request = StubRequest()
+    stream = notifications._event_stream(request, queue)  # type: ignore[attr-defined]
+
+    payload = json.dumps({"title": "Ping"})
+    await queue.put(payload)
+    line = await asyncio.wait_for(stream.__anext__(), timeout=1.0)
+    assert line == f"data: {payload}\n\n"
+
+    disconnect.set()
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(stream.__anext__(), timeout=1.0)
+
+    await notifications.notification_hub.reset()
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_prevents_additional_broadcasts(monkeypatch):
+    """Removing the listener should prevent hub broadcasts."""
+
+    await notifications.notification_hub.reset()
+    client = await _create_stub_client()
+
+    calls = {"count": 0}
+
+    async def fake_broadcast(message):  # pragma: no cover - helper
+        calls["count"] += 1
+
+    monkeypatch.setattr(notifications.notification_hub, "broadcast", fake_broadcast)
+    unsubscribe = await notifications.attach_client_notifications(client)
+    await unsubscribe()
+    message = SimpleNamespace(title="Emergency", content=to_canonical_bytes({"ok": True}))
+    client._callback(message)
+    await asyncio.sleep(0.05)
+    assert calls["count"] == 0


### PR DESCRIPTION
## Summary
- add a reusable notifications router that streams LXMF messages to SSE subscribers
- extend the LXMF client and Emergency Management web gateway to forward unsolicited notifications into the router
- exercise the notification flow with dedicated tests that simulate LXMF callbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d070dbac8325bbfef2f0db7de042