### PR TITLE
Fix flake8 issues in EmergencyManagement example

### DIFF
--- a/examples/EmergencyManagement/__init__.py
+++ b/examples/EmergencyManagement/__init__.py
@@ -1,6 +1,3 @@
-
-
-
 from importlib import import_module
 from types import ModuleType
 from typing import TYPE_CHECKING

--- a/examples/EmergencyManagement/client/__init__.py
+++ b/examples/EmergencyManagement/client/__init__.py
@@ -4,4 +4,3 @@
 from .client import LXMFClient
 
 __all__ = ["LXMFClient"]
-

--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -1,3 +1,6 @@
+import asyncio
+import json
+from pathlib import Path
 import sys
 from typing import Optional
 
@@ -31,30 +34,17 @@ def _ensure_standard_library_on_path() -> None:
                     sys.path.append(candidate)
 
 
+def _ensure_project_root_on_path() -> None:
+    """Allow running the example as a script from the client directory."""
+
+    if __package__ in (None, ""):
+        project_root = Path(__file__).resolve().parents[3]
+        project_root_str = str(project_root)
+        if project_root_str not in sys.path:
+            sys.path.insert(0, project_root_str)
+
+
 _ensure_standard_library_on_path()
-
-import asyncio
-import json
-from pathlib import Path
-
-# Reason: Allow running the example from the client directory by ensuring
-# the project root is on sys.path so that absolute imports resolve.
-if __package__ is None or __package__ == "":
-    project_root = Path(__file__).resolve().parents[3]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
-from examples.EmergencyManagement.client.client import (
-    LXMFClient,
-    create_emergency_action_message,
-    retrieve_emergency_action_message,
-)
-from examples.EmergencyManagement.Server.models_emergency import (
-    EmergencyActionMessage,
-    EAMStatus,
-)
-from reticulum_openapi.identity import load_or_create_identity
 
 
 CONFIG_FILENAME = "client_config.json"
@@ -134,6 +124,19 @@ async def main():
     Responses from the server are decoded from MessagePack into dataclasses
     before printing.
     """
+
+    _ensure_project_root_on_path()
+
+    from examples.EmergencyManagement.client.client import (
+        LXMFClient,
+        create_emergency_action_message,
+        retrieve_emergency_action_message,
+    )
+    from examples.EmergencyManagement.Server.models_emergency import (
+        EmergencyActionMessage,
+        EAMStatus,
+    )
+    from reticulum_openapi.identity import load_or_create_identity
 
     config_data = load_client_config()
     config_path_value = config_data.get(LXMF_CONFIG_PATH_KEY)

--- a/examples/EmergencyManagement/web_gateway/app.py
+++ b/examples/EmergencyManagement/web_gateway/app.py
@@ -57,6 +57,7 @@ def _resolve_gateway_version() -> str:
     except metadata.PackageNotFoundError:
         return "0.1.0-dev"
 
+
 _CONFIG_DATA: ConfigDict = load_client_config(CONFIG_PATH)
 _DEFAULT_SERVER_IDENTITY: Optional[str] = read_server_identity_from_config(
     CONFIG_PATH, _CONFIG_DATA

--- a/tests/examples/emergency_management/test_north_api.py
+++ b/tests/examples/emergency_management/test_north_api.py
@@ -14,8 +14,12 @@ ROOT_PATH = Path(__file__).resolve().parents[3]
 if str(ROOT_PATH) not in sys.path:
     sys.path.append(str(ROOT_PATH))
 
-from examples.EmergencyManagement.client.north_api import config as config_module
-from examples.EmergencyManagement.client.north_api import dependencies as dependencies_module
+config_module = importlib.import_module(
+    "examples.EmergencyManagement.client.north_api.config"
+)
+dependencies_module = importlib.import_module(
+    "examples.EmergencyManagement.client.north_api.dependencies"
+)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- clean up package initialisers to remove extra blank lines flagged by flake8
- defer EmergencyManagement client imports until after path adjustments to satisfy import-order linting
- adjust the web gateway and emergency management tests for compliant spacing and import loading

## Testing
- flake8 --exclude=venv_linux

------
https://chatgpt.com/codex/tasks/task_e_68d3db986164832586b9c6bb3cbd878c