### PR TITLE
Add scheduling widgets and access selector to event form

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -68,6 +68,9 @@
 - [x] Add DestinationAnnouncer helper for LXMF services to broadcast identities.
 - [x] Expose gateway status endpoint for the Emergency Management web UI. (2025-09-23)
 
+## 2025-09-24
+- [x] Add datetime pickers and access dropdown to the EmergencyManagement event form.
+
 ## 2025-09-28
 - [x] Stream EmergencyService notifications to FastAPI subscribers via SSE.
 


### PR DESCRIPTION
## Summary
- switch the event form to datetime-local inputs for start and stale timestamps while normalising ISO payloads
- replace the free-text access field with a dropdown that preserves existing gateway values and update docs in TASK.md
- extend the EventsPage tests to cover the new widgets and ensure create calls emit ISO timestamps

## Testing
- npm run lint
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d3dc17c23c8325b1b69f50bf00e569