### PR TITLE
feat: structure event detail payloads

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -70,6 +70,7 @@
 
 ## 2025-09-24
 - [x] Add datetime pickers and access dropdown to the EmergencyManagement event form.
+- [x] Align EmergencyManagement event detail flows with structured emergency action messages in the web UI and gateway. (2025-09-24)
 
 ## 2025-09-28
 - [x] Stream EmergencyService notifications to FastAPI subscribers via SSE.

--- a/examples/EmergencyManagement/webui/src/index.css
+++ b/examples/EmergencyManagement/webui/src/index.css
@@ -305,6 +305,48 @@ body {
   grid-column: 1 / -1;
 }
 
+.form-section {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+  background-color: #f8fafc;
+}
+
+.form-section__header h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.form-section__header p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.form-section__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.form-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.form-checkbox input {
+  width: auto;
+  accent-color: #2563eb;
+}
+
 .form-card__footer {
   display: flex;
   justify-content: flex-end;
@@ -344,6 +386,36 @@ body {
 
 .status-badge--empty {
   background-color: #e2e8f0;
+  color: #475569;
+}
+
+.events-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.events-detail__headline {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.events-detail__group {
+  color: #475569;
+  font-weight: 500;
+}
+
+.events-detail__statuses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.events-detail__meta {
+  font-size: 0.85rem;
   color: #475569;
 }
 

--- a/examples/EmergencyManagement/webui/src/lib/apiClient.ts
+++ b/examples/EmergencyManagement/webui/src/lib/apiClient.ts
@@ -27,10 +27,14 @@ export interface EventPoint {
   hae?: number | null;
 }
 
+export interface EventDetail {
+  emergencyActionMessage?: EmergencyActionMessage | null;
+}
+
 export interface EventRecord {
   uid: number;
   type?: string | null;
-  detail?: string | null;
+  detail?: EventDetail | null;
   how?: string | null;
   start?: string | null;
   stale?: string | null;


### PR DESCRIPTION
## Summary
- add an EventDetail interface and rework the EventForm to capture emergency action message fields with updated styling and table rendering
- extend EventsPage Vitest coverage for structured detail payloads and add a FastAPI gateway test for nested event data
- record the structured detail alignment work in TASK.md

## Testing
- npm test -- --run
- source venv_linux/bin/activate && pytest tests/examples/emergency_management/test_web_gateway.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e1c3f3208325a4ab5c1705066c5e