### PR TITLE
Fix EAM status collection for test helpers

### DIFF
--- a/examples/EmergencyManagement/client/eam_test.py
+++ b/examples/EmergencyManagement/client/eam_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 from typing import List
+from typing import cast
 
 from examples.EmergencyManagement.Server.models_emergency import (
     EAMStatus,
@@ -49,7 +50,11 @@ COMMUNICATION_METHODS: tuple[str, ...] = (
     "DATA",
 )
 
-_STATUS_VALUES: tuple[EAMStatus, ...] = tuple(EAMStatus)
+_STATUS_VALUES: tuple[EAMStatus, ...] = tuple(
+    cast(EAMStatus, value)
+    for name, value in vars(EAMStatus).items()
+    if not name.startswith("_") and isinstance(value, str)
+)
 
 
 def _random_nato_word() -> str:


### PR DESCRIPTION
## Summary
- collect emergency action message statuses using class attributes instead of attempting to iterate over the type
- ensure the helper values are typed by casting to `EAMStatus`

## Testing
- pytest tests/test_example_emergency_management.py *(fails: EmergencyManagement client module does not expose LXMFClient attribute as expected by existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f48fbef083259cee71b1ca39a43a