### PR TITLE
Add north API event routes and helpers

### DIFF
--- a/examples/EmergencyManagement/client/north_api/app.py
+++ b/examples/EmergencyManagement/client/north_api/app.py
@@ -11,10 +11,12 @@ from .dependencies import ServerIdentityHash
 from .dependencies import get_lxmf_client
 from .dependencies import get_server_identity_hash
 from .dependencies import register_client_events
+from .routes_events import router as events_router
 
 
 app = FastAPI(title="Emergency Management North API Client")
 register_client_events(app)
+app.include_router(events_router)
 
 
 @app.get("/health")

--- a/examples/EmergencyManagement/client/north_api/routes_events.py
+++ b/examples/EmergencyManagement/client/north_api/routes_events.py
@@ -1,0 +1,237 @@
+"""Event routes for the Emergency Management north API client."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import List
+from typing import Literal
+from typing import Optional
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import status
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+from examples.EmergencyManagement.Server.models_emergency import Detail
+from examples.EmergencyManagement.Server.models_emergency import EmergencyActionMessage
+from examples.EmergencyManagement.Server.models_emergency import Event
+from examples.EmergencyManagement.Server.models_emergency import Point
+from examples.EmergencyManagement.client.client import create_event as send_create_event
+from examples.EmergencyManagement.client.client import delete_event as send_delete_event
+from examples.EmergencyManagement.client.client import list_events as send_list_events
+from examples.EmergencyManagement.client.client import (
+    retrieve_event as send_retrieve_event,
+)
+from examples.EmergencyManagement.client.client import update_event as send_update_event
+from examples.EmergencyManagement.client.client import LXMFClient
+
+from .dependencies import ServerIdentityHash
+from .dependencies import get_lxmf_client
+
+
+router = APIRouter(prefix="/events", tags=["events"])
+
+
+class EmergencyActionMessageSchema(BaseModel):
+    """Pydantic representation of an emergency action message."""
+
+    callsign: str
+    groupName: Optional[str] = None
+    securityStatus: Optional[str] = None
+    securityCapability: Optional[str] = None
+    preparednessStatus: Optional[str] = None
+    medicalStatus: Optional[str] = None
+    mobilityStatus: Optional[str] = None
+    commsStatus: Optional[str] = None
+    commsMethod: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class EventDetailSchema(BaseModel):
+    """Nested event detail schema containing emergency action messages."""
+
+    emergencyActionMessage: Optional[EmergencyActionMessageSchema] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class EventPointSchema(BaseModel):
+    """Geographical point information attached to an event."""
+
+    lat: Optional[float] = None
+    lon: Optional[float] = None
+    ce: Optional[float] = None
+    le: Optional[float] = None
+    hae: Optional[float] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class EventSchema(BaseModel):
+    """Full event schema mirroring the LXMF dataclass."""
+
+    uid: int
+    how: Optional[str] = None
+    version: Optional[int] = None
+    time: Optional[int] = None
+    type: Optional[str] = None
+    stale: Optional[str] = None
+    start: Optional[str] = None
+    access: Optional[str] = None
+    opex: Optional[int] = None
+    qos: Optional[int] = None
+    detail: Optional[EventDetailSchema] = None
+    point: Optional[EventPointSchema] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DeleteEventResponseSchema(BaseModel):
+    """Schema describing delete event command responses."""
+
+    status: Literal["deleted", "not_found"]
+    uid: int
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def _convert_emergency_action_message(
+    message: Optional[EmergencyActionMessageSchema],
+) -> Optional[EmergencyActionMessage]:
+    """Convert an emergency action message schema to its dataclass equivalent."""
+
+    if message is None:
+        return None
+    return EmergencyActionMessage(**message.model_dump())
+
+
+def _convert_detail(detail: Optional[EventDetailSchema]) -> Optional[Detail]:
+    """Convert an event detail schema into a dataclass instance."""
+
+    if detail is None:
+        return None
+    payload = detail.model_dump()
+    payload["emergencyActionMessage"] = _convert_emergency_action_message(
+        detail.emergencyActionMessage
+    )
+    return Detail(**payload)
+
+
+def _convert_point(point: Optional[EventPointSchema]) -> Optional[Point]:
+    """Convert an event point schema into a dataclass instance."""
+
+    if point is None:
+        return None
+    return Point(**point.model_dump())
+
+
+def _to_event_dataclass(payload: EventSchema) -> Event:
+    """Convert a Pydantic event schema into the LXMF dataclass."""
+
+    data = payload.model_dump()
+    data["detail"] = _convert_detail(payload.detail)
+    data["point"] = _convert_point(payload.point)
+    return Event(**data)
+
+
+def _from_event_dataclass(event: Event) -> EventSchema:
+    """Convert an event dataclass into its Pydantic schema representation."""
+
+    return EventSchema.model_validate(asdict(event))
+
+
+def _parse_uid(uid: str) -> int:
+    """Return an integer identifier extracted from the path parameter."""
+
+    try:
+        return int(uid)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - FastAPI validation
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="UID must be an integer",
+        ) from exc
+
+
+@router.post("", response_model=EventSchema)
+async def create_event(
+    payload: EventSchema,
+    server_identity: ServerIdentityHash,
+    client: LXMFClient = Depends(get_lxmf_client),
+) -> EventSchema:
+    """Create a new event record on the LXMF service."""
+
+    event = _to_event_dataclass(payload)
+    created = await send_create_event(client, server_identity, event)
+    return _from_event_dataclass(created)
+
+
+@router.get("/{uid}", response_model=EventSchema)
+async def retrieve_event(
+    uid: str,
+    server_identity: ServerIdentityHash,
+    client: LXMFClient = Depends(get_lxmf_client),
+) -> EventSchema:
+    """Return a single event or ``None`` when the identifier is unknown."""
+
+    event_uid = _parse_uid(uid)
+    event = await send_retrieve_event(client, server_identity, event_uid)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
+    return _from_event_dataclass(event)
+
+
+@router.put("/{uid}", response_model=EventSchema)
+async def update_event(
+    uid: str,
+    payload: EventSchema,
+    server_identity: ServerIdentityHash,
+    client: LXMFClient = Depends(get_lxmf_client),
+) -> EventSchema:
+    """Update an existing event record."""
+
+    event_uid = _parse_uid(uid)
+    event_payload = payload.model_copy(update={"uid": event_uid})
+    event = _to_event_dataclass(event_payload)
+    updated = await send_update_event(client, server_identity, event)
+    if updated is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
+    return _from_event_dataclass(updated)
+
+
+@router.delete("/{uid}", response_model=DeleteEventResponseSchema)
+async def delete_event(
+    uid: str,
+    server_identity: ServerIdentityHash,
+    client: LXMFClient = Depends(get_lxmf_client),
+) -> DeleteEventResponseSchema:
+    """Delete an event record by identifier."""
+
+    event_uid = _parse_uid(uid)
+    result = await send_delete_event(client, server_identity, event_uid)
+    status_value = result.get("status")
+    if status_value != "deleted":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
+    return DeleteEventResponseSchema(status="deleted", uid=event_uid)
+
+
+@router.get("", response_model=List[EventSchema])
+async def list_events(
+    server_identity: ServerIdentityHash,
+    client: LXMFClient = Depends(get_lxmf_client),
+) -> List[EventSchema]:
+    """Return all events available on the LXMF service."""
+
+    events = await send_list_events(client, server_identity)
+    return [_from_event_dataclass(event) for event in events]
+
+
+__all__ = ["router"]

--- a/tests/examples/emergency_management/test_north_api.py
+++ b/tests/examples/emergency_management/test_north_api.py
@@ -6,9 +6,15 @@ import importlib
 import json
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from examples.EmergencyManagement.Server.models_emergency import Detail
+from examples.EmergencyManagement.Server.models_emergency import EmergencyActionMessage
+from examples.EmergencyManagement.Server.models_emergency import Event
 
 ROOT_PATH = Path(__file__).resolve().parents[3]
 if str(ROOT_PATH) not in sys.path:
@@ -115,3 +121,196 @@ async def test_register_client_events_lifecycle(monkeypatch):
     assert DummyClient.instance.stopped is True
     with pytest.raises(RuntimeError):
         deps.get_lxmf_client()
+
+
+@pytest.fixture()
+def north_api_test_client(monkeypatch):
+    """Return a configured TestClient with patched dependencies."""
+
+    app_module = importlib.import_module(
+        "examples.EmergencyManagement.client.north_api.app"
+    )
+    routes_module = importlib.import_module(
+        "examples.EmergencyManagement.client.north_api.routes_events"
+    )
+    deps_module = importlib.import_module(
+        "examples.EmergencyManagement.client.north_api.dependencies"
+    )
+
+    app_module = importlib.reload(app_module)
+    routes_module = importlib.reload(routes_module)
+    deps_module = importlib.reload(deps_module)
+
+    stub_client = object()
+    deps_module._client_instance = None
+
+    def _fake_startup() -> None:
+        deps_module._client_instance = stub_client
+
+    def _fake_shutdown() -> None:
+        deps_module._client_instance = None
+
+    monkeypatch.setattr(deps_module, "startup_client", _fake_startup)
+    monkeypatch.setattr(deps_module, "shutdown_client", _fake_shutdown)
+    app_module.app.dependency_overrides[deps_module.get_lxmf_client] = (
+        lambda: stub_client
+    )
+    app_module.app.dependency_overrides[deps_module.get_server_identity_hash] = (
+        lambda: "0011223344556677"
+    )
+
+    with TestClient(app_module.app) as client:
+        yield client, routes_module, stub_client
+
+    app_module.app.dependency_overrides.clear()
+    deps_module._client_instance = None
+
+
+def test_create_event_route_converts_payload(north_api_test_client, monkeypatch):
+    """Creating an event should forward dataclasses to the LXMF helper."""
+
+    client, routes_module, stub_client = north_api_test_client
+
+    created_event = Event(
+        uid=42,
+        detail=Detail(
+            emergencyActionMessage=EmergencyActionMessage(callsign="Bravo"),
+        ),
+    )
+    create_mock = AsyncMock(return_value=created_event)
+    monkeypatch.setattr(routes_module, "send_create_event", create_mock)
+
+    response = client.post(
+        "/events",
+        json={
+            "uid": 42,
+            "detail": {"emergencyActionMessage": {"callsign": "Bravo"}},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["uid"] == 42
+    assert payload["detail"]["emergencyActionMessage"]["callsign"] == "Bravo"
+
+    args, _ = create_mock.await_args
+    assert args[0] is stub_client
+    assert isinstance(args[1], str)
+    assert args[1]
+    assert isinstance(args[2], Event)
+    assert args[2].detail is not None
+    assert args[2].detail.emergencyActionMessage is not None
+    assert args[2].detail.emergencyActionMessage.callsign == "Bravo"
+
+
+def test_retrieve_event_not_found_returns_404(north_api_test_client, monkeypatch):
+    """Retrieving an unknown event should return a 404 response."""
+
+    client, routes_module, stub_client = north_api_test_client
+
+    retrieve_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(routes_module, "send_retrieve_event", retrieve_mock)
+
+    response = client.get("/events/99")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Event not found"
+
+    args, _ = retrieve_mock.await_args
+    assert args[0] is stub_client
+    assert isinstance(args[1], str)
+    assert args[1]
+    assert args[2] == 99
+
+
+def test_update_event_uses_path_identifier(north_api_test_client, monkeypatch):
+    """Updating an event should prefer the path UID over the payload UID."""
+
+    client, routes_module, stub_client = north_api_test_client
+
+    updated_event = Event(uid=21, type="Updated")
+    update_mock = AsyncMock(return_value=updated_event)
+    monkeypatch.setattr(routes_module, "send_update_event", update_mock)
+
+    response = client.put(
+        "/events/21",
+        json={"uid": 10, "type": "Updated"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["uid"] == 21
+    assert payload["type"] == "Updated"
+
+    args, _ = update_mock.await_args
+    assert args[0] is stub_client
+    assert isinstance(args[1], str)
+    assert args[1]
+    assert isinstance(args[2], Event)
+    assert args[2].uid == 21
+
+
+def test_delete_event_not_found_raises_404(north_api_test_client, monkeypatch):
+    """Deleting a missing event should surface a 404 response."""
+
+    client, routes_module, stub_client = north_api_test_client
+
+    delete_mock = AsyncMock(return_value={"status": "not_found", "uid": "5"})
+    monkeypatch.setattr(routes_module, "send_delete_event", delete_mock)
+
+    response = client.delete("/events/5")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Event not found"
+
+    args, _ = delete_mock.await_args
+    assert args[0] is stub_client
+    assert isinstance(args[1], str)
+    assert args[1]
+    assert args[2] == 5
+
+
+def test_delete_event_returns_status_payload(north_api_test_client, monkeypatch):
+    """Deleting an event should return the service status payload."""
+
+    client, routes_module, stub_client = north_api_test_client
+
+    delete_mock = AsyncMock(return_value={"status": "deleted", "uid": "7"})
+    monkeypatch.setattr(routes_module, "send_delete_event", delete_mock)
+
+    response = client.delete("/events/7")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "deleted", "uid": 7}
+
+    args, _ = delete_mock.await_args
+    assert args[0] is stub_client
+    assert isinstance(args[1], str)
+    assert args[1]
+    assert args[2] == 7
+
+
+def test_list_events_returns_serialised_payload(north_api_test_client, monkeypatch):
+    """Listing events should serialise dataclasses to JSON payloads."""
+
+    client, routes_module, stub_client = north_api_test_client
+
+    list_mock = AsyncMock(
+        return_value=[
+            Event(uid=1, type="Alpha"),
+            Event(uid=2, detail=Detail(emergencyActionMessage=None)),
+        ]
+    )
+    monkeypatch.setattr(routes_module, "send_list_events", list_mock)
+
+    response = client.get("/events")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert {event["uid"] for event in payload} == {1, 2}
+
+    args, _ = list_mock.await_args
+    assert args[0] is stub_client
+    assert isinstance(args[1], str)
+    assert args[1]


### PR DESCRIPTION
## Summary
- extend the emergency management client helpers with MessagePack decoding and CRUD helpers for events
- expose `/events` CRUD routes in the north API client using Pydantic schemas and LXMF helpers with proper error handling
- cover the new routes with FastAPI tests exercising conversions and 404 behaviour

## Testing
- venv_linux/bin/flake8 examples/EmergencyManagement/client/client.py examples/EmergencyManagement/client/north_api/routes_events.py examples/EmergencyManagement/client/north_api/app.py tests/examples/emergency_management/test_north_api.py
- venv_linux/bin/pytest tests/examples/emergency_management/test_north_api.py


------
https://chatgpt.com/codex/tasks/task_e_68d3f9c11f148325a50ce5bfa3b3a15b