### PR TITLE
Fix flake8 spacing in emergency management tests

### DIFF
--- a/tests/examples/emergency_management/test_web_gateway.py
+++ b/tests/examples/emergency_management/test_web_gateway.py
@@ -222,6 +222,7 @@ def test_cors_preflight_allows_custom_headers(gateway_app) -> None:
     allow_headers = response.headers.get("access-control-allow-headers", "").lower()
     assert "*" in allow_headers or "x-server-identity" in allow_headers
 
+
 def test_timeout_returns_gateway_timeout(gateway_app) -> None:
     """Transport timeouts are surfaced as HTTP 504 errors."""
 


### PR DESCRIPTION
## Summary
- add a missing blank line between top-level test functions to satisfy flake8 spacing rules

## Testing
- flake8 tests/examples/emergency_management/test_web_gateway.py

------
https://chatgpt.com/codex/tasks/task_e_68d4057c87b0832592f0e6ee435015d8