### PR TITLE
Keep EmergencyManagement client running until interrupted

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -74,4 +74,5 @@
 - [x] Update EmergencyManagement live updates fallback to `/notifications/stream` and align documentation/tests.
 - [x] Align EmergencyManagement event detail flows with structured emergency action messages in the web UI and gateway. (2025-09-24)
 - [x] Stream EmergencyService notifications to FastAPI subscribers via SSE.
+- [x] Ensure EmergencyManagement client runs until interrupted.
 

--- a/tests/examples/emergency_management/test_client_emergency.py
+++ b/tests/examples/emergency_management/test_client_emergency.py
@@ -46,3 +46,16 @@ async def test_prompt_for_server_identity_uses_executor_and_strips(monkeypatch):
         (None, fake_input, (client_emergency.PROMPT_MESSAGE,)),
     ]
     assert prompts["value"] == client_emergency.PROMPT_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_wait_until_interrupted_respects_external_event():
+    """The interruption helper should exit once the provided event is set."""
+
+    stop_event = asyncio.Event()
+    wait_task = asyncio.create_task(
+        client_emergency._wait_until_interrupted(stop_event=stop_event)
+    )
+    await asyncio.sleep(0)
+    stop_event.set()
+    await asyncio.wait_for(wait_task, timeout=0.1)


### PR DESCRIPTION
## Summary
- add an interruption helper so the EmergencyManagement client continues running and waits for signals before shutting down
- keep announce streaming active until shutdown while providing a graceful Ctrl+C message
- document task completion in TASK.md and add coverage for the new shutdown helper

## Testing
- `source venv_linux/bin/activate && pytest tests/examples/emergency_management/test_client_emergency.py`
- `source venv_linux/bin/activate && flake8 examples/EmergencyManagement/client/client_emergency.py tests/examples/emergency_management/test_client_emergency.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4065293a48325b7c3275cffdcd133