### PR TITLE
Reuse JSON config server identity in web gateway

### DIFF
--- a/tests/test_example_emergency_management.py
+++ b/tests/test_example_emergency_management.py
@@ -293,14 +293,29 @@ async def test_main_uses_configured_identity(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(module, "LXMFClient", DummyLXMFClient, raising=False)
     monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.LXMFClient",
+        DummyLXMFClient,
+        raising=False,
+    )
+    monkeypatch.setattr(
         module,
         "create_emergency_action_message",
         fake_create,
         raising=False,
     )
     monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.create_emergency_action_message",
+        fake_create,
+        raising=False,
+    )
+    monkeypatch.setattr(
         module,
         "retrieve_emergency_action_message",
+        fake_retrieve,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.retrieve_emergency_action_message",
         fake_retrieve,
         raising=False,
     )
@@ -356,14 +371,29 @@ async def test_main_prompts_when_config_missing(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(module, "LXMFClient", DummyLXMFClient, raising=False)
     monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.LXMFClient",
+        DummyLXMFClient,
+        raising=False,
+    )
+    monkeypatch.setattr(
         module,
         "create_emergency_action_message",
         fake_create,
         raising=False,
     )
     monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.create_emergency_action_message",
+        fake_create,
+        raising=False,
+    )
+    monkeypatch.setattr(
         module,
         "retrieve_emergency_action_message",
+        fake_retrieve,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.retrieve_emergency_action_message",
         fake_retrieve,
         raising=False,
     )
@@ -427,14 +457,29 @@ async def test_main_prompts_when_config_invalid(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(module, "LXMFClient", DummyLXMFClient, raising=False)
     monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.LXMFClient",
+        DummyLXMFClient,
+        raising=False,
+    )
+    monkeypatch.setattr(
         module,
         "create_emergency_action_message",
         fake_create,
         raising=False,
     )
     monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.create_emergency_action_message",
+        fake_create,
+        raising=False,
+    )
+    monkeypatch.setattr(
         module,
         "retrieve_emergency_action_message",
+        fake_retrieve,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "examples.EmergencyManagement.client.client.retrieve_emergency_action_message",
         fake_retrieve,
         raising=False,
     )


### PR DESCRIPTION
## Summary
- load Emergency Management gateway configuration from the NORTH_API JSON/path environment overrides before falling back to the sample client_config.json
- expose the resolved configuration to the FastAPI gateway default server identity so clean installs inherit the JSON server identity automatically
- extend gateway and client example tests to cover JSON-configured identities and to stub LXMFClient imports consistently

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40b9058e483258e81e3d5efc0c9cf