### PR TITLE
Improve dashboard error handling for dashboard page

### DIFF
--- a/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { apiClient } from '../lib/apiClient';
+import { apiClient, extractApiErrorMessage } from '../lib/apiClient';
 
 interface GatewayInfo {
   version: string;
@@ -14,14 +14,18 @@ export function DashboardPage(): JSX.Element {
   useEffect(() => {
     let isMounted = true;
     async function loadInfo(): Promise<void> {
+      if (isMounted) {
+        setError(null);
+      }
       try {
         const response = await apiClient.get<GatewayInfo>('/');
         if (isMounted) {
           setGatewayInfo(response.data);
+          setError(null);
         }
       } catch (err) {
         if (isMounted) {
-          setError('Unable to reach gateway');
+          setError(extractApiErrorMessage(err));
         }
       }
     }

--- a/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as apiClientModule from '../../lib/apiClient';
+import { DashboardPage } from '../DashboardPage';
+
+describe('DashboardPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders backend error message when loading gateway info fails', async () => {
+    const backendMessage = 'Gateway temporarily offline';
+    const error = new Error('503 Service Unavailable');
+    vi.spyOn(apiClientModule.apiClient, 'get').mockRejectedValueOnce(error);
+    const extractSpy = vi
+      .spyOn(apiClientModule, 'extractApiErrorMessage')
+      .mockReturnValue(backendMessage);
+
+    render(<DashboardPage />);
+
+    expect(await screen.findByText(backendMessage)).toBeInTheDocument();
+    expect(extractSpy).toHaveBeenCalledWith(error);
+  });
+});


### PR DESCRIPTION
## Summary
- clear and restore the dashboard error state around gateway info requests
- surface the backend-provided error message when the gateway request fails
- add a dashboard page test that verifies the backend message is rendered on rejection

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d40bb2eef0832597fb693aa64732a5