### PR TITLE
Configure EmergencyManagement web UI gateway base URL

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -75,4 +75,5 @@
 - [x] Align EmergencyManagement event detail flows with structured emergency action messages in the web UI and gateway. (2025-09-24)
 - [x] Stream EmergencyService notifications to FastAPI subscribers via SSE.
 - [x] Ensure EmergencyManagement client runs until interrupted.
+- [x] Configure EmergencyManagement web UI environment to target the FastAPI gateway base URL. (2025-09-24)
 

--- a/examples/EmergencyManagement/webui/.env.development
+++ b/examples/EmergencyManagement/webui/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- add a committed Vite development environment file that points the Emergency Management web UI at the FastAPI gateway origin
- record the environment configuration update in TASK.md for project tracking

## Testing
- timeout 5s npm run dev -- --host 127.0.0.1 --port 5173 --clearScreen false

------
https://chatgpt.com/codex/tasks/task_e_68d41441eb7883258c4b8f5758d3d22e