### PR TITLE
Handle dashboard API errors with backend message

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -75,4 +75,5 @@
 - [x] Align EmergencyManagement event detail flows with structured emergency action messages in the web UI and gateway. (2025-09-24)
 - [x] Stream EmergencyService notifications to FastAPI subscribers via SSE.
 - [x] Ensure EmergencyManagement client runs until interrupted.
+- [x] Surface dashboard gateway errors using extractApiErrorMessage and recover view state after successful loads.
 

--- a/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
@@ -14,19 +14,23 @@ export function DashboardPage(): JSX.Element {
   useEffect(() => {
     let isMounted = true;
     async function loadInfo(): Promise<void> {
-      if (isMounted) {
-        setError(null);
+      if (!isMounted) {
+        return;
       }
+      setError(null);
       try {
         const response = await apiClient.get<GatewayInfo>('/');
-        if (isMounted) {
-          setGatewayInfo(response.data);
-          setError(null);
+        if (!isMounted) {
+          return;
         }
-      } catch (err) {
-        if (isMounted) {
-          setError(extractApiErrorMessage(err));
+        setGatewayInfo(response.data);
+        setError(null);
+      } catch (err: unknown) {
+        if (!isMounted) {
+          return;
         }
+        setGatewayInfo(null);
+        setError(extractApiErrorMessage(err));
       }
     }
 

--- a/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AxiosResponse } from 'axios';
 
 import * as apiClientModule from '../../lib/apiClient';
 import { DashboardPage } from '../DashboardPage';
@@ -21,5 +22,20 @@ describe('DashboardPage', () => {
 
     expect(await screen.findByText(backendMessage)).toBeInTheDocument();
     expect(extractSpy).toHaveBeenCalledWith(error);
+  });
+
+  it('clears dashboard errors after successfully loading gateway info', async () => {
+    const gatewayInfoResponse = {
+      data: { version: '1.2.3', uptime: '4 hours' },
+    } as AxiosResponse<{ version: string; uptime: string }>;
+    vi.spyOn(apiClientModule.apiClient, 'get').mockResolvedValueOnce(gatewayInfoResponse);
+
+    render(<DashboardPage />);
+
+    expect(await screen.findByText('1.2.3')).toBeInTheDocument();
+    expect(screen.getByText('4 hours')).toBeInTheDocument();
+    expect(
+      screen.queryByText((_, element) => element?.classList.contains('page-error') ?? false),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- reset the dashboard error state before fetching, clear it on success, and surface backend messages when requests fail
- expand the dashboard tests to cover both backend error messaging and clearing the error once gateway info loads

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d415b71c948325b1663f19f0a0460c