### PR TITLE
Document Emergency Management gateway startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,25 @@ pip install -r requirements.txt
 
 ### Running the example server
 
+The Emergency Management example exposes both a Reticulum‑backed service and an HTTP
+gateway implemented with FastAPI. Start the Reticulum service first:
+
 ```bash
 python examples/EmergencyManagement/Server/server_emergency.py
 ```
+
+### Starting the HTTP gateway
+
+Launch the FastAPI gateway with `uvicorn` to serve the OpenAPI on
+`http://localhost:8000`:
+
+```bash
+uvicorn examples.EmergencyManagement.web_gateway.app:app --host 0.0.0.0 --port 8000 --reload
+```
+
+Once the server starts you should see a log message similar to `Uvicorn running on
+http://0.0.0.0:8000`. Visit `http://localhost:8000/docs` for the interactive API docs
+or `http://localhost:8000/` to confirm the health status payload.
 
 ### Running the example client
 

--- a/TASK.md
+++ b/TASK.md
@@ -77,3 +77,6 @@
 - [x] Ensure EmergencyManagement client runs until interrupted.
 - [x] Surface dashboard gateway errors using extractApiErrorMessage and recover view state after successful loads.
 
+## 2025-09-26
+- [x] Document how to start the Emergency Management FastAPI gateway on http://localhost:8000 in the project README.
+


### PR DESCRIPTION
## Summary
- add README instructions for launching the Emergency Management FastAPI gateway with uvicorn on http://localhost:8000
- note how to access the running gateway and docs after startup
- record completion of the documentation update in TASK.md

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d416dd685c83258f3947916ee725cd