### PR TITLE
Default web UI to emergency action messages

### DIFF
--- a/examples/EmergencyManagement/webui/src/components/layout/Sidebar.tsx
+++ b/examples/EmergencyManagement/webui/src/components/layout/Sidebar.tsx
@@ -6,9 +6,9 @@ interface NavItem {
 }
 
 const NAV_LINKS: NavItem[] = [
-  { to: '/', label: 'Dashboard' },
   { to: '/messages', label: 'Emergency Action Messages' },
   { to: '/events', label: 'Events' },
+  { to: '/dashboard', label: 'Dashboard' },
 ];
 
 export function Sidebar(): JSX.Element {
@@ -22,7 +22,7 @@ export function Sidebar(): JSX.Element {
           <NavLink
             key={link.to}
             to={link.to}
-            end={link.to === '/'}
+            end={link.to === '/messages'}
             className={({ isActive }) =>
               `sidebar-link${isActive ? ' sidebar-link-active' : ''}`
             }

--- a/examples/EmergencyManagement/webui/src/router/__tests__/router.test.tsx
+++ b/examples/EmergencyManagement/webui/src/router/__tests__/router.test.tsx
@@ -1,0 +1,53 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../lib/apiClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/apiClient')>();
+  return {
+    ...actual,
+    listEmergencyActionMessages: vi.fn(),
+  };
+});
+
+import { ToastProvider } from '../../components/toast';
+import { listEmergencyActionMessages } from '../../lib/apiClient';
+import { routes } from '../index';
+
+const listMock = vi.mocked(listEmergencyActionMessages);
+
+describe('router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects the root path to the emergency action messages list', async () => {
+    listMock.mockResolvedValue([
+      { callsign: 'Alpha-1', securityStatus: 'Green' },
+      { callsign: 'Bravo-2', securityStatus: 'Yellow' },
+    ]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    const router = createMemoryRouter(routes, { initialEntries: ['/'] });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <RouterProvider router={router} />
+        </ToastProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Emergency Action Messages' })).toBeInTheDocument();
+      expect(screen.getByText('Alpha-1')).toBeInTheDocument();
+      expect(screen.getByText('Bravo-2')).toBeInTheDocument();
+    });
+  });
+});

--- a/examples/EmergencyManagement/webui/src/router/index.tsx
+++ b/examples/EmergencyManagement/webui/src/router/index.tsx
@@ -1,17 +1,21 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { Navigate, createBrowserRouter } from 'react-router-dom';
 
 import { Layout } from '../components/layout/Layout';
 import { DashboardPage } from '../pages/DashboardPage';
 import { EmergencyActionMessagesPage } from '../pages/EmergencyActionMessages/EmergencyActionMessagesPage';
 import { EventsPage } from '../pages/Events/EventsPage';
 
-export const router = createBrowserRouter([
+export const routes = [
   {
     path: '/',
     element: <Layout />,
     children: [
       {
         index: true,
+        element: <Navigate to="messages" replace />,
+      },
+      {
+        path: 'dashboard',
         element: <DashboardPage />,
       },
       {
@@ -24,4 +28,6 @@ export const router = createBrowserRouter([
       },
     ],
   },
-]);
+];
+
+export const router = createBrowserRouter(routes);


### PR DESCRIPTION
## Summary
- redirect the web UI root route to the emergency action messages view and expose the route config for testing
- update the sidebar navigation to highlight the messages view by default
- cover the redirect behaviour with a React Router/React Query integration test

## Testing
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68d4301b3bc08325b5c4f4aaaa26d369