### PR TITLE
Add random event seeder to EmergencyManagement client

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -80,3 +80,6 @@
 ## 2025-09-26
 - [x] Document how to start the Emergency Management FastAPI gateway on http://localhost:8000 in the project README.
 
+## 2025-09-27
+- [x] Add random event seeding helper for the EmergencyManagement client CLI.
+

--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -57,6 +57,9 @@ DEFAULT_TIMEOUT_SECONDS = 30.0
 
 GENERATE_TEST_MESSAGES_KEY = "generate_test_messages"
 TEST_MESSAGE_COUNT = 5
+TEST_MESSAGE_COUNT_KEY = "test_message_count"
+TEST_EVENT_COUNT = 5
+TEST_EVENT_COUNT_KEY = "test_event_count"
 EXAMPLE_IDENTITY_HASH = "761dfb354cfe5a3c9d8f5c4465b6c7f5"
 DEFAULT_CONFIG_DIRECTORY = Path(__file__).resolve().parent / ".reticulum_client"
 DEFAULT_STORAGE_DIRECTORY = DEFAULT_CONFIG_DIRECTORY / "storage"
@@ -184,6 +187,29 @@ def read_server_identity_from_config(
     return None
 
 
+def _coerce_positive_int(value, default: int) -> int:
+    """Return ``value`` as a positive integer when possible."""
+
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        candidate = int(value)
+        if candidate > 0:
+            return candidate
+        return default
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return default
+        try:
+            candidate = int(stripped)
+        except ValueError:
+            return default
+        if candidate > 0:
+            return candidate
+    return default
+
+
 async def main():
     """Send and retrieve an emergency action message.
 
@@ -204,6 +230,7 @@ async def main():
         generate_random_eam,
         seed_test_messages,
     )
+    from examples.EmergencyManagement.client.event_test import RandomEventSeeder
 
     from reticulum_openapi.identity import load_or_create_identity
 
@@ -280,13 +307,31 @@ async def main():
         if server_id is None:
             server_id = await _prompt_for_server_identity()
 
+        message_count_setting = config_data.get(TEST_MESSAGE_COUNT_KEY)
+        event_count_setting = config_data.get(TEST_EVENT_COUNT_KEY)
+        message_count = _coerce_positive_int(
+            message_count_setting,
+            TEST_MESSAGE_COUNT,
+        )
+        event_count = _coerce_positive_int(
+            event_count_setting,
+            TEST_EVENT_COUNT,
+        )
+
         if generate_test_data:
             print("Generating test emergency messages...")
             await seed_test_messages(
                 client,
                 server_id,
-                count=TEST_MESSAGE_COUNT,
+                count=message_count,
             )
+            print("Generating test events...")
+            event_seeder = RandomEventSeeder(
+                client,
+                server_id,
+                count=event_count,
+            )
+            await event_seeder.seed()
 
         eam = generate_random_eam()
         try:

--- a/examples/EmergencyManagement/client/event_test.py
+++ b/examples/EmergencyManagement/client/event_test.py
@@ -1,0 +1,183 @@
+"""Utilities for generating and seeding random Emergency Management events."""
+
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import Callable, List, Optional, Sequence
+
+from examples.EmergencyManagement.Server.models_emergency import (
+    Detail,
+    EmergencyActionMessage,
+    Event,
+    Point,
+)
+from examples.EmergencyManagement.client.client import create_event
+from examples.EmergencyManagement.client.eam_test import generate_random_eam
+
+# Reason: The helper mirrors ``eam_test`` but encapsulates the behaviour inside a
+# class so that the CLI can seed events with deterministic injection during
+# testing.
+
+
+HowValues = Sequence[str]
+
+
+class RandomEventSeeder:
+    """Generate random :class:`Event` payloads and send them to the server."""
+
+    _HOW_VALUES: HowValues = (
+        "m-g",
+        "h-g",
+        "a-f",
+        "a-u",
+    )
+    _TYPE_VALUES: Sequence[str] = (
+        "a-h-G-U-C",
+        "a-h-H",
+        "a-h-E",
+    )
+    _ACCESS_VALUES: Sequence[str] = (
+        "Public",
+        "Restricted",
+        "Private",
+    )
+
+    def __init__(
+        self,
+        client,
+        server_identity: str,
+        *,
+        count: int = 5,
+        random_generator: Optional[random.Random] = None,
+        eam_factory: Callable[[], EmergencyActionMessage] = generate_random_eam,
+    ) -> None:
+        """Initialise the seeder.
+
+        Args:
+            client: Configured LXMF client used to send commands.
+            server_identity (str): Destination identity hash for the LXMF server.
+            count (int): Number of events to seed when :meth:`seed` is invoked.
+            random_generator (Optional[random.Random]): Optional deterministic
+                generator to make testing reproducible.
+            eam_factory (Callable[[], EmergencyActionMessage]): Factory that
+                returns random emergency action messages. Defaults to
+                :func:`generate_random_eam`.
+        """
+
+        if count <= 0:
+            raise ValueError("count must be greater than zero")
+
+        self._client = client
+        self._server_identity = server_identity
+        self._count = count
+        self._random = random_generator or random.Random()
+        self._eam_factory = eam_factory
+        self._generated_uids: set[int] = set()
+
+    def _random_choice(self, values: Sequence[str]) -> Optional[str]:
+        """Return a random element from ``values`` or ``None`` when empty."""
+
+        if not values:
+            return None
+        return self._random.choice(values)
+
+    def _random_uid(self) -> int:
+        """Return a unique positive identifier for an event."""
+
+        while True:
+            candidate = self._random.randint(1, 9_999_999)
+            if candidate not in self._generated_uids:
+                self._generated_uids.add(candidate)
+                return candidate
+
+    def _random_point(self) -> Optional[Point]:
+        """Return a random :class:`Point` or ``None`` if omitted."""
+
+        if self._random.random() < 0.2:
+            return None
+
+        return Point(
+            lat=self._round_coordinate(self._random.uniform(-90.0, 90.0)),
+            lon=self._round_coordinate(self._random.uniform(-180.0, 180.0)),
+            ce=self._round_distance(self._random.uniform(0.0, 500.0)),
+            le=self._round_distance(self._random.uniform(0.0, 500.0)),
+            hae=self._round_distance(self._random.uniform(-100.0, 500.0)),
+        )
+
+    def _round_coordinate(self, value: float) -> float:
+        """Round coordinate values to six decimal places."""
+
+        return float(f"{value:.6f}")
+
+    def _round_distance(self, value: float) -> float:
+        """Round distance values to two decimal places."""
+
+        return float(f"{value:.2f}")
+
+    def _random_detail(self) -> Optional[Detail]:
+        """Return a random :class:`Detail` payload."""
+
+        if self._random.random() < 0.3:
+            return None
+
+        eam = self._eam_factory()
+        return Detail(emergencyActionMessage=replace(eam))
+
+    def generate_random_event(self) -> Event:
+        """Return a randomly populated :class:`Event`."""
+
+        timestamp = int(time.time())
+        stale_time = datetime.now(timezone.utc).isoformat()
+        start_time = datetime.now(timezone.utc).isoformat()
+        detail = self._random_detail()
+        point = self._random_point()
+        return Event(
+            uid=self._random_uid(),
+            how=self._random_choice(self._HOW_VALUES),
+            version=self._random.randint(1, 5),
+            time=timestamp,
+            type=self._random_choice(self._TYPE_VALUES),
+            stale=stale_time,
+            start=start_time,
+            access=self._random_choice(self._ACCESS_VALUES),
+            opex=self._random.randint(1, 10),
+            qos=self._random.randint(1, 10),
+            detail=detail,
+            point=point,
+        )
+
+    async def send_random_event(self) -> Optional[Event]:
+        """Generate and send a random event to the server."""
+
+        event = self.generate_random_event()
+        try:
+            created_event = await create_event(
+                self._client,
+                self._server_identity,
+                event,
+            )
+        except TimeoutError as exc:
+            print(
+                f"Event creation timed out for uid {event.uid}: {exc}",
+            )
+            return None
+        except Exception as exc:  # pragma: no cover - defensive logging
+            print(f"Failed to create event for uid {event.uid}: {exc}")
+            return None
+        return created_event
+
+    async def seed(self) -> List[Event]:
+        """Create multiple random events on the server."""
+
+        created: List[Event] = []
+        for _ in range(self._count):
+            result = await self.send_random_event()
+            if result is not None:
+                created.append(result)
+        return created
+
+
+__all__ = ["RandomEventSeeder"]

--- a/tests/examples/emergency_management/test_event_test.py
+++ b/tests/examples/emergency_management/test_event_test.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from examples.EmergencyManagement.Server.models_emergency import (
+    EmergencyActionMessage,
+    EAMStatus,
+    Event,
+)
+from examples.EmergencyManagement.client import event_test
+from examples.EmergencyManagement.client.event_test import RandomEventSeeder
+
+
+def _eam_factory() -> EmergencyActionMessage:
+    """Return a deterministic emergency action message for tests."""
+
+    return EmergencyActionMessage(
+        callsign="Test1",
+        groupName="Rescue",
+        securityStatus=EAMStatus.Green,
+    )
+
+
+def test_generate_random_event_populates_optional_sections() -> None:
+    """Random events should include optional payloads when generated."""
+
+    rng = random.Random(0)
+    seeder = RandomEventSeeder(
+        client=None,
+        server_identity="abc123",
+        count=1,
+        random_generator=rng,
+        eam_factory=_eam_factory,
+    )
+
+    event = seeder.generate_random_event()
+
+    assert event.uid > 0
+    assert event.version is not None
+    assert event.time is not None
+    assert event.detail is not None
+    assert event.detail.emergencyActionMessage is not None
+    assert event.detail.emergencyActionMessage.callsign == "Test1"
+    assert event.point is not None
+    assert -90.0 <= event.point.lat <= 90.0
+    assert -180.0 <= event.point.lon <= 180.0
+
+
+@pytest.mark.asyncio
+async def test_seed_sends_configured_number_of_events(monkeypatch) -> None:
+    """Seeding should forward the configured number of events to the server."""
+
+    recorded = []
+
+    async def fake_create_event(client, server_identity, event):
+        recorded.append((client, server_identity, event))
+        return event
+
+    monkeypatch.setattr(event_test, "create_event", fake_create_event)
+
+    seeder = RandomEventSeeder(
+        client="client",
+        server_identity="destination",
+        count=3,
+        random_generator=random.Random(1),
+        eam_factory=_eam_factory,
+    )
+
+    results = await seeder.seed()
+
+    assert len(results) == 3
+    assert all(isinstance(item, Event) for item in results)
+    assert [server for _, server, _ in recorded] == ["destination"] * 3
+    assert len({event.uid for _, _, event in recorded}) == 3
+
+
+@pytest.mark.asyncio
+async def test_seed_skips_events_that_timeout(monkeypatch) -> None:
+    """Timeouts during event creation should be logged and ignored."""
+
+    call_count = 0
+    recorded = []
+
+    async def fake_create_event(client, server_identity, event):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise TimeoutError("boom")
+        recorded.append(event)
+        return event
+
+    monkeypatch.setattr(event_test, "create_event", fake_create_event)
+
+    seeder = RandomEventSeeder(
+        client="client",
+        server_identity="destination",
+        count=3,
+        random_generator=random.Random(2),
+        eam_factory=_eam_factory,
+    )
+
+    results = await seeder.seed()
+
+    assert len(results) == 2
+    assert len(recorded) == 2
+
+
+def test_random_event_seeder_rejects_non_positive_count() -> None:
+    """The seeder should refuse non-positive counts."""
+
+    with pytest.raises(ValueError):
+        RandomEventSeeder(
+            client=None,
+            server_identity="dest",
+            count=0,
+        )


### PR DESCRIPTION
## Summary
- add a RandomEventSeeder helper that generates random Event payloads and sends them to the LXMF server
- integrate the new seeder into client_emergency with configurable message and event counts
- cover the helper with asynchronous unit tests and log the completed task

## Testing
- black examples/EmergencyManagement/client/event_test.py examples/EmergencyManagement/client/client_emergency.py tests/examples/emergency_management/test_event_test.py
- flake8 examples/EmergencyManagement/client tests/examples/emergency_management
- pytest tests/examples/emergency_management/test_event_test.py tests/examples/emergency_management/test_client_emergency.py


------
https://chatgpt.com/codex/tasks/task_e_68d431a09e9483258cba9b6289308ee1