### PR TITLE
Reuse codec payload decoder in gateway

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -83,3 +83,6 @@
 ## 2025-09-27
 - [x] Add random event seeding helper for the EmergencyManagement client CLI.
 
+## 2025-09-28
+- [x] Ensure EmergencyManagement FastAPI gateway decodes compressed responses when relaying server commands.
+

--- a/examples/EmergencyManagement/web_gateway/app.py
+++ b/examples/EmergencyManagement/web_gateway/app.py
@@ -36,7 +36,8 @@ from reticulum_openapi.api.notifications import (
     attach_client_notifications,
     router as notifications_router,
 )
-from reticulum_openapi.codec_msgpack import from_bytes
+from reticulum_openapi.codec_msgpack import CodecError
+from reticulum_openapi.codec_msgpack import decode_payload_bytes
 
 
 COMMAND_CREATE_EAM = "CreateEmergencyActionMessage"
@@ -308,7 +309,13 @@ async def _send_command(
 
     if response is None:
         return JSONResponse(content=None)
-    data = from_bytes(response)
+    try:
+        data = decode_payload_bytes(response)
+    except CodecError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
     return JSONResponse(content=data)
 
 


### PR DESCRIPTION
## Summary
- add a shared `decode_payload_bytes` helper to the MessagePack codec for MessagePack, compressed JSON, and plain JSON payloads
- reuse the shared decoder in the EmergencyManagement gateway and notification utilities to avoid duplicate logic

## Testing
- flake8 --exclude=.git,__pycache__,build,dist,venv_linux,venv_linux/*
- pytest tests/examples/emergency_management/test_web_gateway.py


------
https://chatgpt.com/codex/tasks/task_e_68d4369e378483259d9d93ba2e7269b4