### PR TITLE
style: restyle emergency management ui with icons

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -86,3 +86,6 @@
 ## 2025-09-28
 - [x] Ensure EmergencyManagement FastAPI gateway decodes compressed responses when relaying server commands.
 
+## 2025-09-29
+- [x] Refresh EmergencyManagement web UI with dark styling and navigation/status icons inspired by mission dashboard designs.
+

--- a/examples/EmergencyManagement/webui/package-lock.json
+++ b/examples/EmergencyManagement/webui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.59.13",
         "axios": "^1.12.2",
+        "lucide-react": "^0.439.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.28.0"
@@ -3623,6 +3624,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.439.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.439.0.tgz",
+      "integrity": "sha512-PafSWvDTpxdtNEndS2HIHxcNAbd54OaqSYJO90/b63rab2HWYqDbH194j0i82ZFdWOAcf0AHinRykXRRK2PJbw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/lz-string": {

--- a/examples/EmergencyManagement/webui/package.json
+++ b/examples/EmergencyManagement/webui/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "axios": "^1.12.2",
+    "lucide-react": "^0.439.0",
     "@tanstack/react-query": "^5.59.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/EmergencyManagement/webui/src/components/layout/Sidebar.tsx
+++ b/examples/EmergencyManagement/webui/src/components/layout/Sidebar.tsx
@@ -1,21 +1,54 @@
 import { NavLink } from 'react-router-dom';
 
+import type { LucideIcon } from 'lucide-react';
+import {
+  CalendarDays,
+  LayoutDashboard,
+  MessagesSquare,
+  RadioTower,
+} from 'lucide-react';
+
 interface NavItem {
   to: string;
   label: string;
+  description: string;
+  icon: LucideIcon;
 }
 
 const NAV_LINKS: NavItem[] = [
-  { to: '/messages', label: 'Emergency Action Messages' },
-  { to: '/events', label: 'Events' },
-  { to: '/dashboard', label: 'Dashboard' },
+  {
+    to: '/messages',
+    label: 'Action Messages',
+    description: 'Create and dispatch emergency bulletins',
+    icon: MessagesSquare,
+  },
+  {
+    to: '/events',
+    label: 'Events',
+    description: 'Coordinate drills and live incidents',
+    icon: CalendarDays,
+  },
+  {
+    to: '/dashboard',
+    label: 'Dashboard',
+    description: 'Monitor gateway and network health',
+    icon: LayoutDashboard,
+  },
 ];
 
 export function Sidebar(): JSX.Element {
   return (
     <aside className="app-sidebar">
       <div className="sidebar-header">
-        <h1 className="sidebar-title">Emergency Management</h1>
+        <div className="sidebar-logo">
+          <div className="sidebar-logo__mark">
+            <RadioTower size={24} strokeWidth={2.5} aria-hidden="true" />
+          </div>
+          <div className="sidebar-logo__text">
+            <span className="sidebar-logo__title">Emergency Ops</span>
+            <span className="sidebar-logo__subtitle">Rapid Mesh Response</span>
+          </div>
+        </div>
       </div>
       <nav className="sidebar-nav">
         {NAV_LINKS.map((link) => (
@@ -27,7 +60,13 @@ export function Sidebar(): JSX.Element {
               `sidebar-link${isActive ? ' sidebar-link-active' : ''}`
             }
           >
-            {link.label}
+            <span className="sidebar-link__icon" aria-hidden="true">
+              <link.icon size={20} strokeWidth={2.2} />
+            </span>
+            <span className="sidebar-link__content">
+              <span className="sidebar-link__label">{link.label}</span>
+              <span className="sidebar-link__description">{link.description}</span>
+            </span>
           </NavLink>
         ))}
       </nav>

--- a/examples/EmergencyManagement/webui/src/components/layout/TopBar.tsx
+++ b/examples/EmergencyManagement/webui/src/components/layout/TopBar.tsx
@@ -2,17 +2,77 @@ import { useMemo } from 'react';
 
 import { getApiBaseUrl } from '../../lib/apiClient';
 
+import {
+  Activity,
+  Antenna,
+  CloudDownload,
+  Radio,
+  Users,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+interface StatusCard {
+  label: string;
+  value: string;
+  icon: LucideIcon;
+}
+
+const STATUS_CARDS: StatusCard[] = [
+  {
+    label: 'Data Package',
+    value: 'Awaiting sync',
+    icon: CloudDownload,
+  },
+  {
+    label: 'API & Federations',
+    value: 'Listening',
+    icon: Antenna,
+  },
+  {
+    label: 'COT Network',
+    value: 'Standby',
+    icon: Radio,
+  },
+  {
+    label: 'Connected Clients',
+    value: '—',
+    icon: Users,
+  },
+];
+
 export function TopBar(): JSX.Element {
   const gatewayBaseUrl = useMemo(() => getApiBaseUrl(), []);
 
   return (
     <header className="app-topbar">
-      <div>
-        <span className="topbar-label">Mesh Network Status:</span>
-        <span className="topbar-value">Awaiting updates…</span>
+      <div className="topbar-overview">
+        <div className="topbar-network">
+          <span className="topbar-network__icon" aria-hidden="true">
+            <Activity size={20} strokeWidth={2.4} />
+          </span>
+          <div className="topbar-network__content">
+            <span className="topbar-label">Mesh Network</span>
+            <span className="topbar-value">Awaiting updates…</span>
+          </div>
+        </div>
+        <div className="topbar-gateway">
+          <span className="topbar-label">Gateway</span>
+          <code>{gatewayBaseUrl}</code>
+        </div>
       </div>
-      <div className="topbar-gateway">
-        Gateway: <code>{gatewayBaseUrl}</code>
+      <div className="topbar-status-grid">
+        {STATUS_CARDS.map((card) => (
+          <div key={card.label} className="topbar-status-card">
+            <span className="topbar-status-icon" aria-hidden="true">
+              <card.icon size={18} strokeWidth={2.2} />
+            </span>
+            <div className="topbar-status-copy">
+              <span className="topbar-status-label">{card.label}</span>
+              <span className="topbar-status-value">{card.value}</span>
+            </div>
+            <span className="topbar-status-wave" aria-hidden="true" />
+          </div>
+        ))}
       </div>
     </header>
   );

--- a/examples/EmergencyManagement/webui/src/index.css
+++ b/examples/EmergencyManagement/webui/src/index.css
@@ -1,10 +1,28 @@
 :root {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
-  line-height: 1.5;
+  line-height: 1.6;
   font-weight: 400;
-  color: #0f172a;
-  background-color: #f1f5f9;
+  color-scheme: dark;
+  color: var(--text-primary);
+  background-color: var(--bg-body);
+  --bg-body: #030712;
+  --bg-shell: radial-gradient(circle at 20% 20%, #122240 0%, #050b19 58%);
+  --bg-sidebar: linear-gradient(180deg, #091124 0%, #050816 100%);
+  --bg-sidebar-accent: linear-gradient(135deg, #38bdf8 0%, #1d4ed8 100%);
+  --bg-panel: #0c162c;
+  --bg-card: #101d36;
+  --bg-card-soft: rgba(56, 189, 248, 0.12);
+  --bg-card-glow: rgba(14, 165, 233, 0.24);
+  --border-soft: rgba(148, 163, 184, 0.16);
+  --border-strong: rgba(148, 163, 184, 0.28);
+  --text-primary: #e2e8f0;
+  --text-muted: #94a3b8;
+  --text-soft: #cbd5f5;
+  --accent: #38bdf8;
+  --accent-strong: #22d3ee;
+  --shadow-soft: 0 18px 35px rgba(8, 15, 35, 0.42);
+  --shadow-card: 0 20px 45px rgba(15, 23, 42, 0.38);
 }
 
 * {
@@ -18,160 +36,402 @@ body,
 }
 
 body {
-  background-color: inherit;
+  background: var(--bg-shell);
+  color: var(--text-primary);
+}
+
+a {
+  color: inherit;
 }
 
 .app-shell {
   display: flex;
   min-height: 100vh;
+  background: radial-gradient(circle at 60% 0%, rgba(56, 189, 248, 0.08) 0%,
+      rgba(15, 23, 42, 0) 45%),
+    var(--bg-shell);
 }
 
 .app-sidebar {
-  width: 280px;
-  background-color: #0f172a;
-  color: #e2e8f0;
+  width: 300px;
+  background: var(--bg-sidebar);
+  color: var(--text-soft);
   display: flex;
   flex-direction: column;
-  padding: 2rem 1.5rem;
+  padding: 2.5rem 1.75rem 2rem;
+  border-right: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: inset -1px 0 0 rgba(148, 163, 184, 0.06);
+  position: relative;
+  z-index: 2;
+}
+
+.app-sidebar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.15),
+      transparent 62%);
+  opacity: 0.75;
 }
 
 .sidebar-header {
-  margin-bottom: 2rem;
+  margin-bottom: 2.75rem;
+  position: relative;
+  z-index: 1;
 }
 
-.sidebar-title {
-  font-size: 1.5rem;
-  margin: 0;
+.sidebar-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.sidebar-logo__mark {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: var(--bg-sidebar-accent);
+  display: grid;
+  place-items: center;
+  color: #0b1020;
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.25);
+}
+
+.sidebar-logo__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.sidebar-logo__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.sidebar-logo__subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
 }
 
 .sidebar-nav {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
 }
 
 .sidebar-link {
-  color: #cbd5f5;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
   text-decoration: none;
-  padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  color: inherit;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: transform 0.2s ease, border-color 0.2s ease,
+    background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .sidebar-link:hover {
-  background-color: rgba(148, 163, 184, 0.24);
+  transform: translateX(4px);
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 12px 26px rgba(14, 165, 233, 0.22);
+  background: rgba(8, 25, 48, 0.85);
 }
 
 .sidebar-link-active {
-  background-color: #38bdf8;
-  color: #0f172a;
+  border-color: transparent;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.22) 0%,
+      rgba(59, 130, 246, 0.45) 100%);
+  box-shadow: 0 16px 36px rgba(14, 165, 233, 0.35);
+  color: #f8fafc;
+}
+
+.sidebar-link__icon {
+  padding: 0.35rem;
+  border-radius: 0.75rem;
+  background: rgba(14, 165, 233, 0.14);
+  color: var(--accent);
+  display: inline-flex;
+}
+
+.sidebar-link-active .sidebar-link__icon {
+  background: rgba(15, 23, 42, 0.28);
+  color: #f8fafc;
+}
+
+.sidebar-link__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.sidebar-link__label {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.sidebar-link__description {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.68);
 }
 
 .app-content {
   flex: 1;
   display: flex;
   flex-direction: column;
+  position: relative;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.75) 0%,
+      rgba(8, 11, 26, 0.92) 100%);
 }
 
 .app-topbar {
   display: flex;
   justify-content: space-between;
+  align-items: stretch;
+  gap: 2rem;
+  padding: 1.5rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: rgba(11, 18, 32, 0.85);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.55);
+}
+
+.topbar-overview {
+  display: flex;
   align-items: center;
-  padding: 1rem 2rem;
-  background-color: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
+  gap: 1.5rem;
+}
+
+.topbar-network {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.9rem 1.15rem;
+  border-radius: 1.1rem;
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.18),
+      rgba(59, 130, 246, 0.14));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.topbar-network__icon {
+  display: inline-flex;
+  padding: 0.4rem;
+  border-radius: 0.8rem;
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--accent-strong);
+}
+
+.topbar-network__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .topbar-label {
-  font-weight: 600;
-  margin-right: 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(226, 232, 240, 0.68);
 }
 
 .topbar-value {
-  color: #475569;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary);
 }
 
 .topbar-gateway {
-  font-size: 0.9rem;
-  color: #334155;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.9rem 1.15rem;
+  border-radius: 1.1rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: var(--text-soft);
+}
+
+.topbar-gateway code {
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+
+.topbar-status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  flex: 1;
+}
+
+.topbar-status-card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.18),
+      rgba(56, 189, 248, 0.08));
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.topbar-status-icon,
+.topbar-status-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.topbar-status-icon {
+  display: inline-flex;
+  padding: 0.4rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--accent-strong);
+}
+
+.topbar-status-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.topbar-status-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.topbar-status-value {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.topbar-status-wave {
+  position: absolute;
+  inset: -60% -40% auto;
+  height: 200%;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.35),
+      rgba(14, 165, 233, 0.05) 45%, transparent 70%);
+  animation: statusWave 18s linear infinite;
+  opacity: 0.65;
+  z-index: 0;
+}
+
+@keyframes statusWave {
+  0% {
+    transform: translate3d(-10%, 0, 0) rotate(0deg);
+  }
+  50% {
+    transform: translate3d(10%, 0, 0) rotate(12deg);
+  }
+  100% {
+    transform: translate3d(-10%, 0, 0) rotate(0deg);
+  }
 }
 
 .app-main {
   flex: 1;
-  padding: 2rem;
+  padding: 2.25rem 2.5rem;
   overflow-y: auto;
-  background-color: #f8fafc;
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.18) 0%,
+      rgba(15, 23, 42, 0) 55%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.9) 0%, rgba(3, 7, 18, 0.96) 100%);
 }
 
 .page-section {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.8rem;
 }
 
 .page-header h2 {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.45rem;
   font-size: 2rem;
+  letter-spacing: -0.01em;
+  color: #f8fafc;
 }
 
 .page-header p {
   margin: 0;
-  color: #475569;
+  color: var(--text-muted);
 }
 
-.page-card {
-  background-color: #ffffff;
-  border-radius: 1rem;
-  padding: 1.5rem;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+.page-card,
+.table-card,
+.form-card {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.92) 0%,
+      rgba(13, 25, 46, 0.82) 100%);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.page-card h3 {
-  margin-top: 0;
+.page-card h3,
+.table-card__header h3,
+.form-card__header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #f1f5f9;
 }
 
 .page-error {
-  color: #dc2626;
+  color: #f97316;
   font-weight: 600;
 }
 
 .page-definition-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
   margin: 0;
 }
 
 .page-definition-list div {
-  background-color: #f1f5f9;
-  border-radius: 0.75rem;
-  padding: 1rem;
+  background: rgba(12, 30, 57, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 1rem;
+  padding: 1.1rem;
 }
 
 .page-definition-list dt {
   font-weight: 600;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.35rem;
+  color: var(--text-soft);
 }
 
 .page-definition-list dd {
   margin: 0;
-}
-.page-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
-  align-items: start;
+  color: var(--text-primary);
 }
 
-.table-card,
-.form-card {
-  background-color: #ffffff;
-  border-radius: 1rem;
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.15);
-  padding: 1.25rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
+.page-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  align-items: start;
 }
 
 .table-card__header,
@@ -180,11 +440,6 @@ body {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
-}
-
-.table-card__header h3,
-.form-card__header h3 {
-  margin: 0;
 }
 
 .pill {
@@ -198,8 +453,8 @@ body {
 }
 
 .pill--subtle {
-  background-color: #e0f2fe;
-  color: #0369a1;
+  background: rgba(56, 189, 248, 0.14);
+  color: var(--accent);
 }
 
 .table-card__body {
@@ -210,17 +465,25 @@ body {
   width: 100%;
   border-collapse: collapse;
   min-width: 720px;
+  color: var(--text-primary);
 }
 
 .table-card th,
 .table-card td {
-  padding: 0.75rem 1rem;
+  padding: 0.85rem 1rem;
   text-align: left;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.table-card th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.6);
 }
 
 .table-card tbody tr:hover {
-  background-color: rgba(56, 189, 248, 0.12);
+  background: rgba(56, 189, 248, 0.12);
 }
 
 .table-actions {
@@ -231,74 +494,92 @@ body {
 .callsign-cell {
   display: flex;
   flex-direction: column;
+  gap: 0.25rem;
 }
 
 .callsign {
   font-weight: 600;
+  color: #f8fafc;
 }
 
 .callsign-subtitle {
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--text-muted);
 }
 
 .button {
   border: none;
-  border-radius: 0.5rem;
-  padding: 0.6rem 1.1rem;
+  border-radius: 0.75rem;
+  padding: 0.65rem 1.25rem;
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
-  transition: filter 0.15s ease;
-  background-color: #2563eb;
-  color: #ffffff;
+  transition: filter 0.15s ease, transform 0.15s ease;
+  background: linear-gradient(135deg, #38bdf8 0%, #2563eb 100%);
+  color: #0b1020;
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.35);
 }
 
 .button:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .button:hover:not(:disabled) {
-  filter: brightness(0.95);
+  filter: brightness(1.05);
+  transform: translateY(-2px);
 }
 
 .button--secondary {
-  background-color: #e2e8f0;
-  color: #0f172a;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text-soft);
+  box-shadow: none;
 }
 
 .button--danger {
-  background-color: #dc2626;
-  color: #ffffff;
+  background: linear-gradient(135deg, #fb7185 0%, #dc2626 100%);
+  color: #fee2e2;
+  box-shadow: 0 14px 28px rgba(220, 38, 38, 0.28);
 }
 
 .form-grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
 }
 
 .form-field span {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-soft);
 }
 
 .form-field input,
 .form-field select,
 .form-field textarea {
-  padding: 0.65rem 0.75rem;
-  border: 1px solid #cbd5f5;
-  border-radius: 0.5rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.7rem;
   font-size: 0.95rem;
   font-family: inherit;
   resize: vertical;
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text-primary);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.form-field textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
 }
 
 .form-field--wide {
@@ -309,42 +590,42 @@ body {
   grid-column: 1 / -1;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1rem;
-  border-radius: 0.75rem;
-  border: 1px solid #e2e8f0;
-  background-color: #f8fafc;
+  gap: 0.85rem;
+  padding: 1.2rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(11, 26, 49, 0.75);
 }
 
 .form-section__header h4 {
   margin: 0;
   font-size: 1rem;
-  color: #0f172a;
+  color: var(--text-soft);
 }
 
 .form-section__header p {
   margin: 0;
-  color: #475569;
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
 .form-section__grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .form-checkbox {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.55rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-soft);
 }
 
 .form-checkbox input {
   width: auto;
-  accent-color: #2563eb;
+  accent-color: var(--accent);
 }
 
 .form-card__footer {
@@ -353,7 +634,7 @@ body {
 }
 
 .form-error {
-  color: #dc2626;
+  color: #f97316;
   margin: 0;
   font-weight: 600;
 }
@@ -362,7 +643,7 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.25rem 0.5rem;
+  padding: 0.3rem 0.6rem;
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 600;
@@ -370,53 +651,54 @@ body {
 }
 
 .status-badge--green {
-  background-color: #bbf7d0;
-  color: #166534;
+  background: rgba(34, 197, 94, 0.25);
+  color: #bbf7d0;
 }
 
 .status-badge--yellow {
-  background-color: #fef08a;
-  color: #92400e;
+  background: rgba(250, 204, 21, 0.25);
+  color: #fef08a;
 }
 
 .status-badge--red {
-  background-color: #fecaca;
-  color: #b91c1c;
+  background: rgba(248, 113, 113, 0.25);
+  color: #fecaca;
 }
 
 .status-badge--empty {
-  background-color: #e2e8f0;
-  color: #475569;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-muted);
 }
 
 .events-detail {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.4rem;
+  color: var(--text-primary);
 }
 
 .events-detail__headline {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.45rem;
   font-weight: 600;
-  color: #0f172a;
+  color: #f8fafc;
 }
 
 .events-detail__group {
-  color: #475569;
+  color: var(--text-muted);
   font-weight: 500;
 }
 
 .events-detail__statuses {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
+  gap: 0.4rem;
 }
 
 .events-detail__meta {
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--text-muted);
 }
 
 .toast-container {
@@ -433,23 +715,24 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 0.9rem;
   min-width: 240px;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
-  color: #0f172a;
+  box-shadow: 0 22px 40px rgba(8, 15, 35, 0.45);
+  color: #0b1020;
+  font-weight: 600;
 }
 
 .toast-success {
-  background-color: #bbf7d0;
+  background: linear-gradient(135deg, #4ade80 0%, #22c55e 100%);
 }
 
 .toast-error {
-  background-color: #fecdd3;
+  background: linear-gradient(135deg, #fb7185 0%, #dc2626 100%);
 }
 
 .toast-info {
-  background-color: #bfdbfe;
+  background: linear-gradient(135deg, #38bdf8 0%, #2563eb 100%);
 }
 
 .toast-dismiss {
@@ -458,4 +741,5 @@ body {
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;
+  color: inherit;
 }


### PR DESCRIPTION
## Summary
- refresh the Emergency Management web UI with a dark mission-dashboard theme and new navigation branding
- add lucide icons to the sidebar and top status bar with animated health cards
- update shared styling tokens to support the dark theme across cards, tables, forms, and toasts

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d44f6375cc83258ec4843410568f50