### PR TITLE
Expose gateway configuration on dashboard

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -76,6 +76,7 @@
 - [x] Stream EmergencyService notifications to FastAPI subscribers via SSE.
 - [x] Ensure EmergencyManagement client runs until interrupted.
 - [x] Surface dashboard gateway errors using extractApiErrorMessage and recover view state after successful loads.
+- [x] Surface gateway server identity and API configuration details on the dashboard page.
 
 ## 2025-09-26
 - [x] Document how to start the Emergency Management FastAPI gateway on http://localhost:8000 in the project README.

--- a/examples/EmergencyManagement/web_gateway/app.py
+++ b/examples/EmergencyManagement/web_gateway/app.py
@@ -320,13 +320,26 @@ async def _send_command(
 
 
 @app.get("/")
-async def get_gateway_status() -> Dict[str, str]:
-    """Return basic metadata about the running gateway instance."""
+async def get_gateway_status() -> Dict[str, Any]:
+    """Return gateway metadata and configuration details."""
 
     uptime_seconds = (datetime.now(timezone.utc) - _START_TIME).total_seconds()
+    config_path_override = _normalise_optional_path(
+        _CONFIG_DATA.get(LXMF_CONFIG_PATH_KEY)
+    )
+    storage_path_override = _normalise_optional_path(
+        _CONFIG_DATA.get(LXMF_STORAGE_PATH_KEY)
+    )
+
     return {
         "version": _GATEWAY_VERSION,
         "uptime": _format_uptime(uptime_seconds),
+        "serverIdentity": _DEFAULT_SERVER_IDENTITY,
+        "clientDisplayName": _resolve_display_name(_CONFIG_DATA),
+        "requestTimeoutSeconds": _resolve_timeout(_CONFIG_DATA),
+        "lxmfConfigPath": config_path_override or str(CONFIG_PATH),
+        "lxmfStoragePath": storage_path_override,
+        "allowedOrigins": _ALLOWED_ORIGINS,
     }
 
 

--- a/examples/EmergencyManagement/webui/src/lib/apiClient.ts
+++ b/examples/EmergencyManagement/webui/src/lib/apiClient.ts
@@ -81,6 +81,19 @@ if (serverIdentity) {
   apiClient.defaults.headers.common['X-Server-Identity'] = serverIdentity;
 }
 
+export function getConfiguredServerIdentity(): string | undefined {
+  const headerValue = apiClient.defaults.headers.common['X-Server-Identity'];
+  if (typeof headerValue === 'string') {
+    const trimmed = headerValue.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (Array.isArray(headerValue) && headerValue.length > 0) {
+    const firstValue = `${headerValue[0]}`.trim();
+    return firstValue ? firstValue : undefined;
+  }
+  return undefined;
+}
+
 export async function listEmergencyActionMessages(): Promise<EmergencyActionMessage[]> {
   const response = await apiClient.get<EmergencyActionMessage[] | null>(
     '/emergency-action-messages',

--- a/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
@@ -26,14 +26,39 @@ describe('DashboardPage', () => {
 
   it('clears dashboard errors after successfully loading gateway info', async () => {
     const gatewayInfoResponse = {
-      data: { version: '1.2.3', uptime: '4 hours' },
-    } as AxiosResponse<{ version: string; uptime: string }>;
+      data: {
+        version: '1.2.3',
+        uptime: '4 hours',
+        serverIdentity: 'abc123',
+        clientDisplayName: 'Responder',
+        requestTimeoutSeconds: 45.5,
+        lxmfConfigPath: '/tmp/config.json',
+        lxmfStoragePath: '/tmp/storage',
+        allowedOrigins: ['https://example.com'],
+      },
+    } as AxiosResponse<{
+      version: string;
+      uptime: string;
+      serverIdentity?: string | null;
+      clientDisplayName: string;
+      requestTimeoutSeconds: number;
+      lxmfConfigPath: string | null;
+      lxmfStoragePath: string | null;
+      allowedOrigins: string[];
+    }>;
     vi.spyOn(apiClientModule.apiClient, 'get').mockResolvedValueOnce(gatewayInfoResponse);
 
     render(<DashboardPage />);
 
     expect(await screen.findByText('1.2.3')).toBeInTheDocument();
     expect(screen.getByText('4 hours')).toBeInTheDocument();
+    expect(screen.getByText('Responder')).toBeInTheDocument();
+    expect(screen.getByText('45.5 seconds')).toBeInTheDocument();
+    expect(screen.getByText('/tmp/config.json')).toBeInTheDocument();
+    expect(screen.getByText('/tmp/storage')).toBeInTheDocument();
+    expect(screen.getByText('https://example.com')).toBeInTheDocument();
+    expect(screen.getByText('http://localhost:8000')).toBeInTheDocument();
+    expect(screen.getByText('http://localhost:8000/notifications/stream')).toBeInTheDocument();
     expect(
       screen.queryByText((_, element) => element?.classList.contains('page-error') ?? false),
     ).not.toBeInTheDocument();

--- a/tests/examples/emergency_management/test_web_gateway.py
+++ b/tests/examples/emergency_management/test_web_gateway.py
@@ -309,3 +309,13 @@ def test_gateway_status_returns_version_and_uptime(gateway_app) -> None:
     assert payload["version"] == module._GATEWAY_VERSION
     assert isinstance(payload["uptime"], str)
     assert payload["uptime"].count(":") == 2
+    assert payload["serverIdentity"] == module._DEFAULT_SERVER_IDENTITY
+    assert payload["clientDisplayName"] == module._resolve_display_name(
+        module._CONFIG_DATA
+    )
+    assert payload["requestTimeoutSeconds"] == module._resolve_timeout(
+        module._CONFIG_DATA
+    )
+    assert payload["lxmfConfigPath"] == str(module.CONFIG_PATH)
+    assert payload["lxmfStoragePath"] is None
+    assert payload["allowedOrigins"] == module._ALLOWED_ORIGINS


### PR DESCRIPTION
## Summary
- extend the Emergency Management gateway status endpoint to return server identity and LXMF client configuration details
- surface gateway configuration and web UI API settings on the dashboard along with helper utilities
- update tests and task tracking to cover the richer gateway status payload

## Testing
- npx vitest run
- source venv_linux/bin/activate && pytest tests/examples/emergency_management/test_web_gateway.py -q --color=no

------
https://chatgpt.com/codex/tasks/task_e_68d450c51cc883259e85cccbc89eeb29