### PR TITLE
Align gateway RPC key configuration

### DIFF
--- a/examples/EmergencyManagement/.reticulum/config
+++ b/examples/EmergencyManagement/.reticulum/config
@@ -1,0 +1,15 @@
+# Reticulum configuration for the Emergency Management example stack.
+# This mirrors the default Reticulum template with a fixed RPC key so
+# the LXMF service, FastAPI gateway, and supporting tools can connect to
+# the same shared instance while running on a single workstation.
+
+[reticulum]
+  enable_transport = False
+  share_instance = Yes
+  instance_name = emergency-default
+  rpc_key = F1E2D3C4B5A697887766554433221100
+
+[interfaces]
+  [[Auto Interface]]
+    type = AutoInterface
+    enabled = Yes

--- a/examples/EmergencyManagement/README.md
+++ b/examples/EmergencyManagement/README.md
@@ -50,12 +50,14 @@ Both the CLI demo and the FastAPI gateway read [`client/client_config.json`](cli
   "client_display_name": "Emergency Client",
   "request_timeout_seconds": 30,
   "lxmf_config_path": null,
-  "lxmf_storage_path": null
+  "lxmf_storage_path": null,
+  "shared_instance_rpc_key": "<hex rpc key>"
 }
 ```
 
 - Override the location of the configuration file with `NORTH_API_CONFIG_PATH` or provide JSON directly through `NORTH_API_CONFIG_JSON`.
 - Requests can target different LXMF services by supplying an `X-Server-Identity` header or a `server_identity` query parameter to the gateway.
+- The repository ships with a sample Reticulum directory at [`examples/EmergencyManagement/.reticulum`](./.reticulum) that pins `rpc_key` to `F1E2D3C4B5A697887766554433221100`. When the gateway and LXMF service use this directory (or any config with the same key) they can attach to the same shared instance without prompting.
 
 ### Web UI environment
 

--- a/examples/EmergencyManagement/client/README.md
+++ b/examples/EmergencyManagement/client/README.md
@@ -1,3 +1,3 @@
 # Emergency Management northbound client
 
-The full stack setup—including the shared LXMF client, FastAPI gateway, and CLI demo—is documented in the consolidated [Emergency Management README](../README.md). Refer to that guide for configuration values, startup commands, and build instructions.
+The full stack setup—including the shared LXMF client, FastAPI gateway, and CLI demo—is documented in the consolidated [Emergency Management README](../README.md). Refer to that guide for configuration values, startup commands, and build instructions. The sample [`client_config.json`](client_config.json) now also includes a `shared_instance_rpc_key` entry so the CLI, web gateway, and LXMF service can all authenticate with the bundled Reticulum configuration under [`../.reticulum`](../.reticulum).

--- a/examples/EmergencyManagement/client/client_config.json
+++ b/examples/EmergencyManagement/client/client_config.json
@@ -4,5 +4,6 @@
   "request_timeout_seconds": 30,
   "lxmf_config_path": null,
   "lxmf_storage_path": null,
-  "generate_test_messages": true
+  "generate_test_messages": true,
+  "shared_instance_rpc_key": "F1E2D3C4B5A697887766554433221100"
 }

--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -51,6 +51,7 @@ CLIENT_DISPLAY_NAME_KEY = "client_display_name"
 REQUEST_TIMEOUT_KEY = "request_timeout_seconds"
 LXMF_CONFIG_PATH_KEY = "lxmf_config_path"
 LXMF_STORAGE_PATH_KEY = "lxmf_storage_path"
+SHARED_INSTANCE_RPC_KEY = "shared_instance_rpc_key"
 DEFAULT_DISPLAY_NAME = "OpenAPIClient"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 
@@ -104,6 +105,7 @@ __all__ = [
     "main",
     "read_server_identity_from_config",
     "load_client_config",
+    "SHARED_INSTANCE_RPC_KEY",
 ]
 
 
@@ -251,6 +253,14 @@ async def main():
     else:
         storage_path_override = str(DEFAULT_STORAGE_DIRECTORY)
 
+    rpc_key_value = config_data.get(SHARED_INSTANCE_RPC_KEY)
+    if isinstance(rpc_key_value, str):
+        rpc_key_value = rpc_key_value.strip()
+        if not rpc_key_value:
+            rpc_key_value = None
+    else:
+        rpc_key_value = None
+
     identity_config_dir = Path(identity_config_path)
     try:
         identity_config_dir.mkdir(parents=True, exist_ok=True)
@@ -277,6 +287,7 @@ async def main():
         identity=client_identity,
         display_name=display_name,
         timeout=timeout_seconds,
+        shared_instance_rpc_key=rpc_key_value,
     )
 
     client.listen_for_announces()

--- a/examples/EmergencyManagement/client/north_api/config.py
+++ b/examples/EmergencyManagement/client/north_api/config.py
@@ -31,6 +31,7 @@ class NorthAPIClientSettings(BaseModel):
     request_timeout_seconds: float = Field(300.0, ge=0.0)
     lxmf_config_path: Optional[str] = None
     lxmf_storage_path: Optional[str] = None
+    shared_instance_rpc_key: Optional[str] = None
 
     @field_validator("server_identity_hash")
     def _validate_server_identity_hash(cls, value: str) -> str:
@@ -58,6 +59,28 @@ class NorthAPIClientSettings(BaseModel):
             return None
         cleaned = str(value).strip()
         return cleaned or None
+
+    @field_validator("shared_instance_rpc_key", mode="before")
+    def _validate_shared_instance_rpc_key(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        """Normalise and validate optional RPC key overrides."""
+
+        if value is None:
+            return None
+
+        cleaned = str(value).strip()
+        if not cleaned:
+            return None
+
+        try:
+            bytes.fromhex(cleaned)
+        except ValueError as exc:
+            raise ValueError(
+                "shared_instance_rpc_key must be a hexadecimal string"
+            ) from exc
+
+        return cleaned.lower()
 
 
 def _load_config_from_json(raw_json: str) -> Dict[str, Any]:

--- a/examples/EmergencyManagement/client/north_api/dependencies.py
+++ b/examples/EmergencyManagement/client/north_api/dependencies.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import Depends
 from fastapi import FastAPI
@@ -27,6 +26,7 @@ def _create_client(settings: NorthAPIClientSettings) -> LXMFClient:
         storage_path=settings.lxmf_storage_path,
         display_name=settings.client_display_name,
         timeout=settings.request_timeout_seconds,
+        shared_instance_rpc_key=settings.shared_instance_rpc_key,
     )
 
 

--- a/examples/EmergencyManagement/web_gateway/app.py
+++ b/examples/EmergencyManagement/web_gateway/app.py
@@ -29,6 +29,7 @@ from examples.EmergencyManagement.client.client_emergency import (
     LXMF_CONFIG_PATH_KEY,
     LXMF_STORAGE_PATH_KEY,
     REQUEST_TIMEOUT_KEY,
+    SHARED_INSTANCE_RPC_KEY,
     load_client_config,
     read_server_identity_from_config,
 )
@@ -154,6 +155,15 @@ def _normalise_optional_path(value: Optional[str]) -> Optional[str]:
     return None
 
 
+def _normalise_optional_hex(value: Optional[str]) -> Optional[str]:
+    """Return a stripped hexadecimal string or ``None`` when empty."""
+
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned or None
+    return None
+
+
 def _resolve_timeout(config: ConfigDict) -> float:
     """Return the timeout value configured for the client."""
 
@@ -181,6 +191,9 @@ def _create_client_from_config() -> LXMFClient:
     storage_path_override = _normalise_optional_path(
         _CONFIG_DATA.get(LXMF_STORAGE_PATH_KEY)
     )
+    rpc_key_override = _normalise_optional_hex(
+        _CONFIG_DATA.get(SHARED_INSTANCE_RPC_KEY)
+    )
     timeout_seconds = _resolve_timeout(_CONFIG_DATA)
     display_name = _resolve_display_name(_CONFIG_DATA)
 
@@ -189,6 +202,7 @@ def _create_client_from_config() -> LXMFClient:
         storage_path=storage_path_override,
         display_name=display_name,
         timeout=timeout_seconds,
+        shared_instance_rpc_key=rpc_key_override,
     )
     client.announce()
     return client

--- a/tests/examples/emergency_management/test_north_api.py
+++ b/tests/examples/emergency_management/test_north_api.py
@@ -52,6 +52,7 @@ def test_load_config_from_environment_json(monkeypatch):
         "request_timeout_seconds": 42.0,
         "lxmf_config_path": "/tmp/config.cfg",
         "lxmf_storage_path": "/tmp/storage",
+        "shared_instance_rpc_key": "A1B2C3D4",
     }
     monkeypatch.setenv("NORTH_API_CONFIG_JSON", json.dumps(config_data))
     monkeypatch.delenv("NORTH_API_CONFIG_PATH", raising=False)
@@ -63,6 +64,7 @@ def test_load_config_from_environment_json(monkeypatch):
     assert settings.request_timeout_seconds == config_data["request_timeout_seconds"]
     assert settings.lxmf_config_path == config_data["lxmf_config_path"]
     assert settings.lxmf_storage_path == config_data["lxmf_storage_path"]
+    assert settings.shared_instance_rpc_key == "a1b2c3d4"
 
 
 @pytest.mark.asyncio
@@ -75,6 +77,7 @@ async def test_register_client_events_lifecycle(monkeypatch):
         "request_timeout_seconds": 10.0,
         "lxmf_config_path": None,
         "lxmf_storage_path": None,
+        "shared_instance_rpc_key": "BEEF",
     }
     monkeypatch.setenv("NORTH_API_CONFIG_JSON", json.dumps(config_data))
     monkeypatch.delenv("NORTH_API_CONFIG_PATH", raising=False)
@@ -91,11 +94,13 @@ async def test_register_client_events_lifecycle(monkeypatch):
             storage_path=None,
             display_name=None,
             timeout=None,
+            shared_instance_rpc_key=None,
         ):
             self.config_path = config_path
             self.storage_path = storage_path
             self.display_name = display_name
             self.timeout = timeout
+            self.shared_instance_rpc_key = shared_instance_rpc_key
             self.stopped = False
             DummyClient.instance = self
 
@@ -114,6 +119,7 @@ async def test_register_client_events_lifecycle(monkeypatch):
     assert isinstance(client, DummyClient)
     assert client.display_name == config_data["client_display_name"]
     assert client.timeout == config_data["request_timeout_seconds"]
+    assert client.shared_instance_rpc_key == "beef"
 
     for handler in app.router.on_shutdown:
         await handler()


### PR DESCRIPTION
## Summary
- allow the Emergency Management LXMF client helper to supply a shared-instance RPC key to the base Reticulum client
- plumb the new configuration field through the FastAPI gateway, northbound API, and CLI along with updated docs and sample config
- cover the new shared-instance key handling in unit tests and provide a default Reticulum stack that uses the same key

## Testing
- pytest tests/examples/emergency_management/test_web_gateway.py::test_create_event_accepts_structured_detail -q
- pytest tests/examples/emergency_management/test_north_api.py::test_load_config_from_environment_json -q

------
https://chatgpt.com/codex/tasks/task_e_68d44eb19d608325a4e2ab2456875ea8