### PR TITLE
Add link support to LXMF service

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -90,3 +90,6 @@
 ## 2025-09-29
 - [x] Refresh EmergencyManagement web UI with dark styling and navigation/status icons inspired by mission dashboard designs.
 
+## 2025-09-30
+- [x] Enable LXMF service link support and extend automated coverage.
+


### PR DESCRIPTION
## Summary
- enable LXMFService to accept RNS links with configurable handlers and keepalive management
- announce and clean up link destinations safely even when the service is constructed in tests
- extend the LXMF service test suite to cover link flows and updated mocks

## Testing
- pytest tests/api tests/examples -q
- pytest tests/test_service.py -q
- pytest tests/test_service_extra.py -q
- pytest tests/test_example_filmology.py -q
- pytest tests/test_example_linkdemo_imports.py -q
- pytest tests/test_announcer.py -q
- pytest tests/test_client.py -q
- pytest tests/test_client_extra.py -q
- pytest tests/test_codec_msgpack.py -q
- pytest tests/test_controller.py -q
- pytest tests/test_identity.py -q
- pytest tests/test_link_client.py -q
- pytest tests/test_link_resources.py -q
- pytest tests/test_link_service.py -q
- pytest tests/test_logging_config.py -q
- pytest tests/test_model.py -q
- pytest tests/test_model_extra.py -q
- pytest tests/test_persistence.py -q
- pytest tests/test_status.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d4728a4f58832598203b21579be761