### PR TITLE
Establish LXMF link at gateway startup and surface status

### DIFF
--- a/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
@@ -8,6 +8,15 @@ import {
   getLiveUpdatesUrl,
 } from '../lib/apiClient';
 
+interface LinkStatus {
+  state: 'pending' | 'connected' | 'error' | 'unconfigured' | 'unknown';
+  message?: string | null;
+  serverIdentity?: string | null;
+  lastAttempt?: string | null;
+  lastSuccess?: string | null;
+  lastError?: string | null;
+}
+
 interface GatewayInfo {
   version: string;
   uptime: string;
@@ -17,6 +26,7 @@ interface GatewayInfo {
   lxmfConfigPath?: string | null;
   lxmfStoragePath?: string | null;
   allowedOrigins?: string[];
+  linkStatus?: LinkStatus | null;
 }
 
 export function DashboardPage(): JSX.Element {
@@ -37,6 +47,12 @@ export function DashboardPage(): JSX.Element {
         : [],
     [gatewayInfo],
   );
+  const linkStatus = gatewayInfo?.linkStatus ?? null;
+  const resolvedLinkMessage = linkStatus?.message ?? 'No link status reported yet.';
+  const resolvedLinkState = linkStatus?.state ?? 'unknown';
+  const resolvedLastSuccess = linkStatus?.lastSuccess ?? 'Never';
+  const resolvedLastAttempt = linkStatus?.lastAttempt ?? 'Never';
+  const resolvedLastError = linkStatus?.lastError ?? null;
 
   useEffect(() => {
     let isMounted = true;
@@ -88,6 +104,28 @@ export function DashboardPage(): JSX.Element {
               <dt>Uptime</dt>
               <dd>{gatewayInfo.uptime}</dd>
             </div>
+            <div>
+              <dt>Link State</dt>
+              <dd>{resolvedLinkState}</dd>
+            </div>
+            <div>
+              <dt>Link Status</dt>
+              <dd>{resolvedLinkMessage}</dd>
+            </div>
+            <div>
+              <dt>Last Successful Link</dt>
+              <dd>{resolvedLastSuccess}</dd>
+            </div>
+            <div>
+              <dt>Last Link Attempt</dt>
+              <dd>{resolvedLastAttempt}</dd>
+            </div>
+            {resolvedLastError && (
+              <div>
+                <dt>Last Link Error</dt>
+                <dd>{resolvedLastError}</dd>
+              </div>
+            )}
           </dl>
         )}
       </div>

--- a/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
@@ -35,6 +35,13 @@ describe('DashboardPage', () => {
         lxmfConfigPath: '/tmp/config.json',
         lxmfStoragePath: '/tmp/storage',
         allowedOrigins: ['https://example.com'],
+        linkStatus: {
+          state: 'connected' as const,
+          message: 'Connected to LXMF server abc123',
+          lastSuccess: '2025-09-23T12:34:56Z',
+          lastAttempt: '2025-09-23T12:34:56Z',
+          lastError: null,
+        },
       },
     } as AxiosResponse<{
       version: string;
@@ -45,6 +52,13 @@ describe('DashboardPage', () => {
       lxmfConfigPath: string | null;
       lxmfStoragePath: string | null;
       allowedOrigins: string[];
+      linkStatus: {
+        state: 'pending' | 'connected' | 'error' | 'unconfigured' | 'unknown';
+        message?: string | null;
+        lastSuccess?: string | null;
+        lastAttempt?: string | null;
+        lastError?: string | null;
+      };
     }>;
     vi.spyOn(apiClientModule.apiClient, 'get').mockResolvedValueOnce(gatewayInfoResponse);
 
@@ -57,6 +71,10 @@ describe('DashboardPage', () => {
     expect(screen.getByText('/tmp/config.json')).toBeInTheDocument();
     expect(screen.getByText('/tmp/storage')).toBeInTheDocument();
     expect(screen.getByText('https://example.com')).toBeInTheDocument();
+    expect(screen.getByText('connected')).toBeInTheDocument();
+    expect(screen.getByText('Connected to LXMF server abc123')).toBeInTheDocument();
+    const timestampMatches = screen.getAllByText('2025-09-23T12:34:56Z');
+    expect(timestampMatches).toHaveLength(2);
     expect(screen.getByText('http://localhost:8000')).toBeInTheDocument();
     expect(screen.getByText('http://localhost:8000/notifications/stream')).toBeInTheDocument();
     expect(


### PR DESCRIPTION
## Summary
- ensure the LXMF client exposes a public ensure_link helper for startup linking
- establish the gateway's LXMF link on startup, track the link status and return it from the status endpoint
- surface link health on the dashboard UI and extend tests across Python and Vitest suites

## Testing
- pytest tests/examples/emergency_management/test_web_gateway.py -vv
- pytest tests/test_client_extra.py -q
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d485e4c0cc832590f0e7a1062330d5