### PR TITLE
Retry gateway link until connected

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -92,4 +92,5 @@
 
 ## 2025-09-30
 - [x] Enable LXMF service link support and extend automated coverage.
+- [x] Ensure EmergencyManagement gateway retries LXMF link until connection established. (2025-09-30)
 


### PR DESCRIPTION
## Summary
- add a retrying background task that keeps establishing the LXMF link until success and logs the successful connection to stdout
- capture retry status updates/cancellation on shutdown for the gateway link monitor and surface messages via `_LINK_STATUS`
- extend gateway tests to cover retry behaviour, success logging, and fixture cleanup plus document the work item in `TASK.md`

## Testing
- pytest -k web_gateway -q

------
https://chatgpt.com/codex/tasks/task_e_68d52d2a9c0083258b75858641bc0b48