### PR TITLE
Remove unused global declaration in gateway startup handler

### DIFF
--- a/examples/EmergencyManagement/web_gateway/app.py
+++ b/examples/EmergencyManagement/web_gateway/app.py
@@ -330,7 +330,6 @@ async def _startup() -> None:
     """Ensure the LXMF client is ready before serving requests."""
 
     client = get_shared_client()
-    global _LINK_STATUS
     global _LINK_TASK
     server_identity = _DEFAULT_SERVER_IDENTITY
     if server_identity:


### PR DESCRIPTION
## Summary
- drop the unused global declaration for `_LINK_STATUS` in the Emergency Management web gateway startup handler to satisfy flake8 F824

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d53e3759788325bd3a95ea8eff9fa9