### PR TITLE
Fix LXMF link routing to register destination handlers

### DIFF
--- a/tests/test_example_emergency_management.py
+++ b/tests/test_example_emergency_management.py
@@ -408,6 +408,15 @@ async def test_main_uses_configured_identity(monkeypatch, tmp_path) -> None:
         fake_retrieve,
         raising=False,
     )
+    async def immediate_wait(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        module,
+        "_wait_until_interrupted",
+        immediate_wait,
+        raising=False,
+    )
 
     await module.main()
 
@@ -487,6 +496,15 @@ async def test_main_prompts_when_config_missing(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         "examples.EmergencyManagement.client.client.retrieve_emergency_action_message",
         fake_retrieve,
+        raising=False,
+    )
+    async def immediate_wait(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        module,
+        "_wait_until_interrupted",
+        immediate_wait,
         raising=False,
     )
 
@@ -576,6 +594,15 @@ async def test_main_prompts_when_config_invalid(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         "examples.EmergencyManagement.client.client.retrieve_emergency_action_message",
         fake_retrieve,
+        raising=False,
+    )
+    async def immediate_wait(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        module,
+        "_wait_until_interrupted",
+        immediate_wait,
         raising=False,
     )
 


### PR DESCRIPTION
## Summary
- register LXMF link request handlers on the service destination and execute command handlers on the asyncio loop
- update service and example tests to reflect destination-based routing and cover the new dispatcher
- patch Emergency Management client example tests to bypass the interactive wait

## Testing
- pytest --maxfail=1 --disable-warnings -q

------
https://chatgpt.com/codex/tasks/task_e_68d59f779b90832594755a9978b25053