### PR TITLE
Expose Reticulum interface status in gateway and dashboard

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -96,6 +96,9 @@
 
 - [x] Add HTTP integration tests for the EmergencyManagement web UI message and event flows.
 
+## 2025-09-25
+- [x] Surface active Reticulum interfaces in the EmergencyManagement gateway startup logs and dashboard.
+
 ## 2025-10-01
 - [x] Upgrade esbuild dependency to version 0.25.0 or later to address the development server request vulnerability.
 

--- a/examples/EmergencyManagement/web_gateway/interface_status.py
+++ b/examples/EmergencyManagement/web_gateway/interface_status.py
@@ -1,0 +1,64 @@
+"""Helpers for reporting Reticulum interface status."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import RNS
+from RNS.Interfaces import Interface as RNSInterface
+
+
+def _resolve_interface_mode_name(mode: Optional[int]) -> Optional[str]:
+    """Return a descriptive name for a Reticulum interface mode."""
+
+    if mode is None:
+        return None
+    mapping = {
+        RNSInterface.Interface.MODE_FULL: "full",
+        RNSInterface.Interface.MODE_ACCESS_POINT: "access_point",
+        RNSInterface.Interface.MODE_POINT_TO_POINT: "point_to_point",
+        RNSInterface.Interface.MODE_ROAMING: "roaming",
+    }
+    return mapping.get(mode, str(mode))
+
+
+def _resolve_interface_name(interface: Any, index: int) -> str:
+    """Return a human readable name for a Reticulum interface."""
+
+    name_value = getattr(interface, "name", None)
+    if isinstance(name_value, str) and name_value.strip():
+        return name_value.strip()
+    return f"Interface-{index}"
+
+
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    """Return an integer value when possible."""
+
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def gather_interface_status() -> List[Dict[str, Any]]:
+    """Return status metadata for all configured Reticulum interfaces."""
+
+    statuses: List[Dict[str, Any]] = []
+    for index, interface in enumerate(RNS.Transport.interfaces):
+        mode_value = getattr(interface, "mode", None)
+        bitrate_value = _coerce_optional_int(getattr(interface, "bitrate", None))
+        statuses.append(
+            {
+                "id": f"{type(interface).__name__}:{index}",
+                "name": _resolve_interface_name(interface, index),
+                "type": type(interface).__name__,
+                "online": bool(getattr(interface, "online", False)),
+                "mode": _resolve_interface_mode_name(mode_value),
+                "bitrate": bitrate_value,
+            }
+        )
+    return statuses

--- a/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/__tests__/DashboardPage.test.tsx
@@ -42,6 +42,24 @@ describe('DashboardPage', () => {
           lastAttempt: '2025-09-23T12:34:56Z',
           lastError: null,
         },
+        reticulumInterfaces: [
+          {
+            id: 'AutoInterface:0',
+            name: 'Mesh Neighbors',
+            type: 'AutoInterface',
+            online: true,
+            mode: 'full',
+            bitrate: 125000,
+          },
+          {
+            id: 'TCPClientInterface:1',
+            name: 'WAN Link',
+            type: 'TCPClientInterface',
+            online: false,
+            mode: 'access_point',
+            bitrate: null,
+          },
+        ],
       },
     } as AxiosResponse<{
       version: string;
@@ -59,6 +77,14 @@ describe('DashboardPage', () => {
         lastAttempt?: string | null;
         lastError?: string | null;
       };
+      reticulumInterfaces: {
+        id: string;
+        name: string;
+        type: string;
+        online: boolean;
+        mode?: string | null;
+        bitrate?: number | null;
+      }[];
     }>;
     vi.spyOn(apiClientModule.apiClient, 'get').mockResolvedValueOnce(gatewayInfoResponse);
 
@@ -75,6 +101,12 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Connected to LXMF server abc123')).toBeInTheDocument();
     const timestampMatches = screen.getAllByText('2025-09-23T12:34:56Z');
     expect(timestampMatches).toHaveLength(2);
+    expect(screen.getByText('Mesh Neighbors • full • 125000 bps')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Mesh Neighbors • full • 125000 bps (online), WAN Link • access_point (offline)',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText('http://localhost:8000')).toBeInTheDocument();
     expect(screen.getByText('http://localhost:8000/notifications/stream')).toBeInTheDocument();
     expect(


### PR DESCRIPTION
## Summary
- refresh Reticulum interface metadata during gateway startup, log the active interfaces, and expose the data from the status endpoint
- add a helper module for collecting interface details and update the dashboard to surface active and configured interfaces
- extend FastAPI and Vitest suites to cover the new interface reporting and mark the task as completed

## Testing
- pytest tests/examples/emergency_management/test_web_gateway.py
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d5aa4d227c8325826ec28e766c294f