### PR TITLE
Align LXMF link handler with RNS callback signature

### DIFF
--- a/reticulum_openapi/service.py
+++ b/reticulum_openapi/service.py
@@ -294,11 +294,30 @@ class LXMFService:
         path: Any,
         request_data: Any,
         request_id: Any,
-        *extra: Any,
+        link_or_identity: Any,
+        remote_identity_or_requested_at: Any,
+        requested_at: Any = None,
     ) -> Optional[bytes]:
         """Handle link requests dispatched via ``RNS.Destination`` hooks."""
 
+        if requested_at is None:
+            remote_identity = link_or_identity
+            link_id = None
+            requested_timestamp = remote_identity_or_requested_at
+        else:
+            link_id = link_or_identity
+            remote_identity = remote_identity_or_requested_at
+            requested_timestamp = requested_at
+
         command_candidate = self._extract_command_from_path(path)
+
+        logger.debug(
+            "Handling link command %s (link=%r remote=%r requested_at=%r)",  # Reason: aid diagnostics
+            command_candidate or path,
+            link_id,
+            getattr(remote_identity, "hash", remote_identity),
+            requested_timestamp,
+        )
         if command_candidate is None:
             logger.warning("Received link request with invalid path: %r", path)
             return None

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -335,7 +335,14 @@ async def test_link_request_dispatches_routes() -> None:
     assert callable(request_handler)
 
     def _invoke_handler() -> Optional[bytes]:
-        return request_handler("/commands/PING", b"", object())
+        return request_handler(
+            "/commands/PING",
+            b"",
+            object(),
+            b"lk",
+            object(),
+            123.0,
+        )
 
     payload = await loop.run_in_executor(None, _invoke_handler)
     assert msgpack_from_bytes(payload) == {"status": "ok"}

--- a/tests/test_service_extra.py
+++ b/tests/test_service_extra.py
@@ -359,6 +359,9 @@ async def test_handle_registered_link_request_dispatches():
             "/commands/CMD",
             payload,
             request_id=object(),
+            link_or_identity=b"lk",
+            remote_identity_or_requested_at=SimpleNamespace(hash=b"remote"),
+            requested_at=123.0,
         ),
     )
 
@@ -366,3 +369,18 @@ async def test_handle_registered_link_request_dispatches():
     decoded = service_module.msgpack_from_bytes(response)
     assert decoded["ok"] is True
     assert decoded["echo"]["value"] == 1
+
+    legacy_response = await loop.run_in_executor(
+        None,
+        lambda: svc._handle_registered_link_request(
+            "/commands/CMD",
+            payload,
+            object(),
+            SimpleNamespace(hash=b"legacy"),
+            321.0,
+        ),
+    )
+
+    assert legacy_response is not None
+    decoded_legacy = service_module.msgpack_from_bytes(legacy_response)
+    assert decoded_legacy["ok"] is True


### PR DESCRIPTION
## Summary
- update the LXMF service link handler signature to accept the parameters required by the latest RNS callback contract and log the caller context
- adjust link request unit tests to exercise the six-argument callback and cover the legacy five-argument path

## Testing
- `python -m venv venv_linux`
- `source venv_linux/bin/activate`
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5b04b39d88325ad62ae8726e9fd6b