### PR TITLE
Fix flake8 spacing before nested async helpers

### DIFF
--- a/tests/test_example_emergency_management.py
+++ b/tests/test_example_emergency_management.py
@@ -408,6 +408,7 @@ async def test_main_uses_configured_identity(monkeypatch, tmp_path) -> None:
         fake_retrieve,
         raising=False,
     )
+
     async def immediate_wait(*args, **kwargs):
         return None
 
@@ -498,6 +499,7 @@ async def test_main_prompts_when_config_missing(monkeypatch, tmp_path) -> None:
         fake_retrieve,
         raising=False,
     )
+
     async def immediate_wait(*args, **kwargs):
         return None
 
@@ -596,6 +598,7 @@ async def test_main_prompts_when_config_invalid(monkeypatch, tmp_path) -> None:
         fake_retrieve,
         raising=False,
     )
+
     async def immediate_wait(*args, **kwargs):
         return None
 


### PR DESCRIPTION
## Summary
- add the missing blank lines before nested async helpers in the EmergencyManagement client tests to satisfy flake8 E306

## Testing
- source venv_linux/bin/activate && flake8 tests/test_example_emergency_management.py

------
https://chatgpt.com/codex/tasks/task_e_68d684556bdc83259f01612e99849ade