### PR TITLE
Add CLI configuration for EmergencyManagement server

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,19 @@ The Emergency Management example exposes both a Reticulum‑backed service and a
 gateway implemented with FastAPI. Start the Reticulum service first:
 
 ```bash
-python examples/EmergencyManagement/Server/server_emergency.py
+python examples/EmergencyManagement/Server/server_emergency.py \
+  --config-path ~/.reticulum \
+  --storage-path ~/.reticulum/lxmf \
+  --display-name "Emergency Ops" \
+  --auth-token YOUR_TOKEN \
+  --link-keepalive-interval 30 \
+  --database-path ./emergency.db
 ```
+
+All flags are optional; omit them to fall back to the defaults embedded in the
+example. At startup the server prints the announced identity hash, command
+destination hash, and the active configuration so that clients can copy the
+values without digging through the code.
 
 ### Starting the HTTP gateway
 

--- a/TASK.md
+++ b/TASK.md
@@ -85,5 +85,6 @@
 ## 2025-09-26
 - [x] Derive EmergencyManagement database configuration from the server module path and expose runtime overrides.
 - [x] Add sortable tables to the EmergencyManagement web UI for messages and events.
+- [x] Extend EmergencyManagement server CLI to accept runtime overrides and document usage.
 
 

--- a/docs/emergency_management_architecture.md
+++ b/docs/emergency_management_architecture.md
@@ -7,6 +7,17 @@ associated event reports. The upcoming FastAPI gateway will reuse the existing
 LXMF service stack while presenting a northbound REST API for web and mobile
 clients.
 
+### Runtime configuration
+
+The LXMF service located at
+`examples/EmergencyManagement/Server/server_emergency.py` accepts command-line
+flags so operators can point the process at different Reticulum configurations,
+LXMF storage directories, database locations, and authentication tokens without
+editing the source code. The same CLI also controls the announced display name
+and link keepalive interval. When the service starts it prints a summary of the
+effective settings alongside the identity and destination hashes used by LXMF
+clients and gateways.
+
 ## Emergency Action Message Operations
 
 | Operation | LXMF Command | Controller Method | Input Dataclass | Output |

--- a/tests/examples/emergency_management/test_server_cli.py
+++ b/tests/examples/emergency_management/test_server_cli.py
@@ -1,0 +1,120 @@
+"""Tests for the Emergency Management server CLI helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from examples.EmergencyManagement.Server import server_emergency
+
+
+class _StubService:
+    """Async context manager that captures invocation parameters."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.announced = False
+        self.destination = SimpleNamespace(hash=b"\x01" * 16)
+        self.source_identity = SimpleNamespace(hash=b"\x02" * 16)
+        self.link_destination = SimpleNamespace(hash=b"\x03" * 16)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def announce(self):
+        self.announced = True
+
+
+@pytest.mark.asyncio
+async def test_main_threads_cli_arguments(monkeypatch, capsys):
+    """Parsed CLI options should propagate into the service and database calls."""
+
+    configure_calls = []
+    init_calls = []
+
+    class _Factory(_StubService):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self_created["instance"] = self
+
+    self_created = {}
+
+    monkeypatch.setattr(
+        server_emergency,
+        "_ensure_dependencies_loaded",
+        lambda: None,
+    )
+    monkeypatch.setattr(server_emergency, "EmergencyService", _Factory)
+
+    def _fake_configure(url):
+        configure_calls.append(url)
+        return "configured://database"
+
+    async def _fake_init(url):
+        init_calls.append(url)
+
+    monkeypatch.setattr(server_emergency, "configure_database", _fake_configure)
+    monkeypatch.setattr(server_emergency, "init_db", _fake_init)
+    monkeypatch.setattr(
+        server_emergency,
+        "_register_shutdown_signals",
+        lambda stop_event: stop_event.set(),
+    )
+
+    options = server_emergency._parse_args(
+        [
+            "--config-path",
+            "/var/lib/reticulum",
+            "--storage-path",
+            "/var/lib/lxmf",
+            "--display-name",
+            "Emergency Ops",
+            "--auth-token",
+            "secret-token",
+            "--link-keepalive-interval",
+            "15.5",
+            "--database-path",
+            "/tmp/emergency.db",
+        ]
+    )
+
+    await server_emergency.main(options=options)
+
+    stub_service = self_created["instance"]
+    assert stub_service.announced is True
+    assert stub_service.kwargs == {
+        "config_path": "/var/lib/reticulum",
+        "storage_path": "/var/lib/lxmf",
+        "display_name": "Emergency Ops",
+        "auth_token": "secret-token",
+        "link_keepalive_interval": 15.5,
+    }
+    assert configure_calls == ["/tmp/emergency.db"]
+    assert init_calls == ["configured://database"]
+
+    output = capsys.readouterr().out
+    assert "Emergency Management service is running." in output
+    assert "configured://database" in output
+    assert "01010101010101010101010101010101" in output
+
+
+def test_database_override_priority():
+    """The CLI should prefer explicit URLs over filesystem paths."""
+
+    options = server_emergency._parse_args(
+        [
+            "--database",
+            "./fallback.db",
+            "--database-path",
+            "./preferred.db",
+            "--database-url",
+            "postgresql+asyncpg://user:pass@host/db",
+        ]
+    )
+
+    override = server_emergency._select_database_override(options)
+    assert override == "postgresql+asyncpg://user:pass@host/db"


### PR DESCRIPTION
## Summary
- add command-line options to the Emergency Management server for Reticulum paths, LXMF storage, display name, auth token, keepalive interval, and database overrides
- print a startup summary reflecting announced destinations and active settings so operators can copy values easily
- document the runtime flags and cover the parsing/propagation logic with dedicated tests

## Testing
- pytest tests/examples/emergency_management/test_server_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d68b42493c83259fa5b391a8efe0da