### PR TITLE
Stack dashboard cards vertically

### DIFF
--- a/examples/EmergencyManagement/webui/src/index.css
+++ b/examples/EmergencyManagement/webui/src/index.css
@@ -436,8 +436,10 @@ a {
   hyphens: auto;
 }
 
-.page-grid--dashboard {
-  grid-template-columns: minmax(0, 1fr);
+.dashboard-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
 }
 
 .page-grid {

--- a/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
@@ -123,7 +123,7 @@ export function DashboardPage(): JSX.Element {
         <h2>Dashboard</h2>
         <p>High-level overview of the Emergency Management gateway.</p>
       </header>
-      <div className="page-grid page-grid--dashboard">
+      <div className="dashboard-layout">
         <div className="page-card">
           <h3>Gateway Status</h3>
           {error && <p className="page-error">{error}</p>}


### PR DESCRIPTION
## Summary
- replace the dashboard grid container with a vertical layout so the Gateway Status card spans the full width
- keep Gateway Configuration beneath the status details and the Web UI API configuration anchored at the bottom of the stack

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d6bc6c2b348325a43a4c3069a304ee