### PR TITLE
Adjust dashboard layout to stack status cards vertically

### DIFF
--- a/examples/EmergencyManagement/webui/package-lock.json
+++ b/examples/EmergencyManagement/webui/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/node": "^20.19.17",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -1674,6 +1675,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -4634,6 +4645,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/examples/EmergencyManagement/webui/package.json
+++ b/examples/EmergencyManagement/webui/package.json
@@ -11,9 +11,9 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.59.13",
     "axios": "^1.12.2",
     "lucide-react": "^0.439.0",
-    "@tanstack/react-query": "^5.59.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0"
@@ -22,6 +22,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^20.19.17",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.14.0",

--- a/examples/EmergencyManagement/webui/src/index.css
+++ b/examples/EmergencyManagement/webui/src/index.css
@@ -415,6 +415,16 @@ a {
   }
 }
 
+.dashboard-layout__status-card .page-definition-list {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .dashboard-layout__status-card .page-definition-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 .page-definition-list div {
   background: rgba(12, 30, 57, 0.7);
   border: 1px solid rgba(148, 163, 184, 0.16);
@@ -437,9 +447,14 @@ a {
 }
 
 .dashboard-layout {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 1.75rem;
+}
+
+.dashboard-layout__status-card,
+.dashboard-layout__configuration-card,
+.dashboard-layout__api-card {
+  width: 100%;
 }
 
 .page-grid {

--- a/examples/EmergencyManagement/webui/src/lib/__tests__/apiClient.integration.test.ts
+++ b/examples/EmergencyManagement/webui/src/lib/__tests__/apiClient.integration.test.ts
@@ -3,6 +3,8 @@ import { type AddressInfo } from 'node:net';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { type EventRecord } from '../apiClient';
+
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let body = '';
@@ -183,7 +185,7 @@ describe('apiClient HTTP integration', () => {
   it('posts and retrieves events via HTTP', async () => {
     const { createEvent, listEvents, retrieveEvent } = await import('../apiClient');
 
-    const event = {
+    const event: EventRecord = {
       uid: 42,
       type: 'drill',
       detail: {

--- a/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
+++ b/examples/EmergencyManagement/webui/src/pages/DashboardPage.tsx
@@ -124,7 +124,7 @@ export function DashboardPage(): JSX.Element {
         <p>High-level overview of the Emergency Management gateway.</p>
       </header>
       <div className="dashboard-layout">
-        <div className="page-card">
+        <div className="page-card dashboard-layout__status-card">
           <h3>Gateway Status</h3>
           {error && <p className="page-error">{error}</p>}
           {!error && !gatewayInfo && <p>Loading gateway information…</p>}
@@ -184,7 +184,7 @@ export function DashboardPage(): JSX.Element {
           )}
         </div>
         {gatewayInfo && (
-          <div className="page-card">
+          <div className="page-card dashboard-layout__configuration-card">
             <h3>Gateway Configuration</h3>
             <dl className="page-definition-list">
               <div>
@@ -222,7 +222,7 @@ export function DashboardPage(): JSX.Element {
             </dl>
           </div>
         )}
-        <div className="page-card">
+        <div className="page-card dashboard-layout__api-card">
           <h3>Web UI API Configuration</h3>
           <dl className="page-definition-list">
             <div>


### PR DESCRIPTION
## Summary
- stack the dashboard status, configuration, and API cards vertically so the Gateway Status occupies the full width
- tweak dashboard styles so the status metrics use a responsive column layout without crowding

## Testing
- npm run build *(fails: existing TypeScript tests reference unavailable Node modules and implicit any types)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c4279a048325ab6d87a5d7af18a1