### PR TITLE
Add LXMF announce metadata support

### DIFF
--- a/examples/EmergencyManagement/Server/service_emergency.py
+++ b/examples/EmergencyManagement/Server/service_emergency.py
@@ -13,6 +13,7 @@ class EmergencyService(LXMFService):
     """Service with routes for the emergency management example."""
 
     def __init__(self, *args, **kwargs):
+        kwargs.setdefault("announce_app_data", "emergency_management")
         super().__init__(*args, **kwargs)
 
         eamc = EmergencyController()

--- a/reticulum_openapi/announcer.py
+++ b/reticulum_openapi/announcer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Optional
+from typing import Union
 
 import RNS
 
@@ -25,6 +26,7 @@ class DestinationAnnouncer:
         *,
         direction: Optional[int] = None,
         destination_type: Optional[int] = None,
+        app_data: Optional[Union[bytes, str]] = None,
     ) -> None:
         """Initialise the announcer with destination metadata.
 
@@ -36,6 +38,9 @@ class DestinationAnnouncer:
                 direction. Defaults to ``RNS.Destination.IN``.
             destination_type (Optional[int]): Override for the Reticulum
                 destination type. Defaults to ``RNS.Destination.SINGLE``.
+            app_data (Optional[Union[bytes, str]]): Metadata transmitted with
+                the announce packet. Strings are encoded as UTF-8 prior to
+                assignment. Defaults to ``None``.
 
         Raises:
             ValueError: If ``identity`` is ``None``.
@@ -58,6 +63,12 @@ class DestinationAnnouncer:
             application,
             aspect,
         )
+        if isinstance(app_data, str):
+            app_data_bytes: Optional[bytes] = app_data.encode("utf-8")
+        else:
+            app_data_bytes = app_data
+        if app_data_bytes is not None:
+            self.destination.default_app_data = app_data_bytes
 
     def announce(self) -> bytes:
         """Send an announce packet for the configured destination.

--- a/tests/test_announcer.py
+++ b/tests/test_announcer.py
@@ -13,6 +13,9 @@ def test_destination_announcer_creates_destination(monkeypatch):
     announced = {"called": False}
 
     class FakeDestination:
+        IN = object()
+        SINGLE = object()
+
         def __init__(self, identity, direction, destination_type, application, aspect):
             self.identity = identity
             self.direction = direction
@@ -20,6 +23,7 @@ def test_destination_announcer_creates_destination(monkeypatch):
             self.application = application
             self.aspect = aspect
             self.hash = b"hash"
+            self.default_app_data = None
 
         def announce(self):
             announced["called"] = True
@@ -57,3 +61,57 @@ def test_destination_announcer_requires_identity():
 
     with pytest.raises(ValueError):
         DestinationAnnouncer(None, "app", "aspect")
+
+
+def test_destination_announcer_sets_default_app_data(monkeypatch):
+    """App data supplied during construction should populate the destination."""
+
+    class FakeDestination:
+        IN = object()
+        SINGLE = object()
+
+        def __init__(self, *_args, **_kwargs):
+            self.hash = b"hash"
+            self.default_app_data = None
+
+    fake_rns = SimpleNamespace(
+        Destination=FakeDestination,
+        LOG_WARNING=1,
+        log=lambda *args, **kwargs: None,
+        prettyhexrep=lambda value: "hash",
+    )
+    monkeypatch.setattr("reticulum_openapi.announcer.RNS", fake_rns)
+
+    identity = object()
+    announcer = DestinationAnnouncer(
+        identity,
+        "app",
+        "aspect",
+        app_data=b"metadata",
+    )
+
+    assert announcer.destination.default_app_data == b"metadata"
+
+
+def test_destination_announcer_accepts_string_app_data(monkeypatch):
+    """String app data should be encoded as UTF-8 before assignment."""
+
+    class FakeDestination:
+        IN = object()
+        SINGLE = object()
+
+        def __init__(self, *_args, **_kwargs):
+            self.hash = b"hash"
+            self.default_app_data = None
+
+    fake_rns = SimpleNamespace(
+        Destination=FakeDestination,
+        LOG_WARNING=1,
+        log=lambda *args, **kwargs: None,
+        prettyhexrep=lambda value: "hash",
+    )
+    monkeypatch.setattr("reticulum_openapi.announcer.RNS", fake_rns)
+
+    announcer = DestinationAnnouncer(object(), "app", "aspect", app_data="text")
+
+    assert announcer.destination.default_app_data == b"text"


### PR DESCRIPTION
## Summary
- add optional announce metadata support to DestinationAnnouncer and LXMFService
- default the EmergencyService announce metadata to an emergency management service type
- extend unit tests to verify default app data propagation through announces

## Testing
- pytest tests/test_announcer.py tests/examples/emergency_management/test_server_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d82c885a348325bf9e19fc3286deff