### PR TITLE
Expand EmergencyManagement OpenAPI coverage

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -88,3 +88,6 @@
 - [x] Extend EmergencyManagement server CLI to accept runtime overrides and document usage.
 
 
+## 2025-09-27
+- [x] Expand EmergencyManagement OpenAPI specification with notifications streaming and updated schemas.
+

--- a/examples/EmergencyManagement/API/EmergencyActionMessageManagement-OAS.yaml
+++ b/examples/EmergencyManagement/API/EmergencyActionMessageManagement-OAS.yaml
@@ -3,6 +3,8 @@ info:
   title: EmergencyActionMessageManagement
   version: '3.0'
   description: >-
+    OpenAPI definition for the Emergency Management LXMF service and
+    supporting streaming notifications API.
   contact:
     name: FreeTAKTeam
     url: https://github.com/FreeTAKTeam
@@ -10,318 +12,420 @@ info:
   license:
     name: EPL
 paths:
-  /Event/{id}:
-    get:
-      x-scope: public
-      tags:
-       - Event
-      description: >-
-      summary: retrieve an existing Event record based on the provided ID.
-      operationId: RetrieveEvent
-      parameters:
-        - $ref: '#/components/parameters/ID'
-      responses:
-        '200':
-          $ref: '#/components/responses/200Event_get'
-    delete:
-      x-scope: public
-      tags:
-       - Event
-      description: >-
-      summary: Deletes an existing Event record based on the provided ID.
-      operationId: DeleteEvent
-      parameters:
-        - $ref: '#/components/parameters/ID'
-      responses:
-        '200':
-          $ref: '#/components/responses/200Event_delete'
   /EmergencyActionMessage:
     post:
       x-scope: public
       tags:
-       - EmergencyActionMessage
-      description: >-
+        - EmergencyActionMessage
       summary: Creates a new EmergencyActionMessage record.
+      description: >-
+        Persists a new emergency action message identified by its callsign.
       operationId: CreateEmergencyActionMessage
       requestBody:
         $ref: '#/components/requestBodies/EmergencyActionMessage'
       responses:
         '200':
-          $ref: '#/components/responses/200EmergencyActionMessage_post'
+          $ref: '#/components/responses/EmergencyActionMessageResponse'
     get:
       x-scope: public
       tags:
-       - EmergencyActionMessage
+        - EmergencyActionMessage
+      summary: Retrieves a list of all EmergencyActionMessage records.
       description: >-
-      summary: Retrieves a list of all EmergencyActionMessage
+        Returns every stored emergency action message. The list is empty when
+        no records exist.
       operationId: ListEmergencyActionMessage
       responses:
         '200':
-          $ref: '#/components/responses/200EmergencyActionMessage_get'
+          $ref: '#/components/responses/EmergencyActionMessageCollection'
     put:
       x-scope: public
       tags:
-       - EmergencyActionMessage
-      description: >-
+        - EmergencyActionMessage
       summary: Updates an existing EmergencyActionMessage record.
+      description: >-
+        Applies updated field values to an existing emergency action message.
+        The request body must include the callsign identifying the record.
       operationId: PutEmergencyActionMessage
       requestBody:
         $ref: '#/components/requestBodies/EmergencyActionMessage'
       responses:
         '200':
-          $ref: '#/components/responses/200EmergencyActionMessage_put'
-  /Event/EmergencyActionMessage:
+          $ref: '#/components/responses/EmergencyActionMessageNullableResponse'
+  /EmergencyActionMessage/{callsign}:
+    parameters:
+      - $ref: '#/components/parameters/EmergencyActionMessageCallsign'
+    get:
+      x-scope: public
+      tags:
+        - EmergencyActionMessage
+      summary: Retrieves a specific EmergencyActionMessage by callsign.
+      description: >-
+        Returns the emergency action message associated with the supplied
+        callsign. When the callsign is unknown, ``null`` is returned.
+      operationId: RetrieveEmergencyActionMessage
+      responses:
+        '200':
+          $ref: '#/components/responses/EmergencyActionMessageNullableResponse'
+    delete:
+      x-scope: public
+      tags:
+        - EmergencyActionMessage
+      summary: Deletes an existing EmergencyActionMessage record.
+      description: >-
+        Removes the emergency action message identified by the provided
+        callsign.
+      operationId: DeleteEmergencyActionMessage
+      responses:
+        '200':
+          $ref: '#/components/responses/DeleteEmergencyActionMessageResponse'
+  /Event:
     post:
       x-scope: public
       tags:
-       - Event
-       -  EmergencyActionMessage
-      description: >-
+        - Event
       summary: Creates a new Event record.
+      description: >-
+        Persists a TAK event identified by its ``uid`` field.
       operationId: CreateEvent
       requestBody:
         $ref: '#/components/requestBodies/Event'
       responses:
         '200':
-          $ref: '#/components/responses/200Event_post'
+          $ref: '#/components/responses/EventResponse'
     get:
       x-scope: public
       tags:
-       - Event
+        - Event
+      summary: Retrieves a list of all Event records.
       description: >-
-      summary: Retrieves a list of all Event
+        Returns every stored event. The list is empty when no records exist.
       operationId: ListEvent
       responses:
         '200':
-          $ref: '#/components/responses/200Event_get'
+          $ref: '#/components/responses/EventCollection'
     put:
       x-scope: public
       tags:
-       - Event
-      description: >-
+        - Event
       summary: Updates an existing Event record.
+      description: >-
+        Applies updated field values to an existing event. The request body must
+        include the ``uid`` identifying the record.
       operationId: PutEvent
       requestBody:
         $ref: '#/components/requestBodies/Event'
       responses:
         '200':
-          $ref: '#/components/responses/200Event_put'
-  /EmergencyActionMessage/{id}:
+          $ref: '#/components/responses/EventNullableResponse'
+  /Event/{uid}:
+    parameters:
+      - $ref: '#/components/parameters/EventUID'
     get:
       x-scope: public
       tags:
-       - EmergencyActionMessage
+        - Event
+      summary: Retrieves a specific Event by UID.
       description: >-
-      summary: retrieve an existing EmergencyActionMessage record based on the provided ID.
-      operationId: RetrieveEmergencyActionMessage
-      parameters:
-        - $ref: '#/components/parameters/ID'
+        Returns the event associated with the supplied UID. When the UID is
+        unknown, ``null`` is returned.
+      operationId: RetrieveEvent
       responses:
         '200':
-          $ref: '#/components/responses/200EmergencyActionMessage_get'
+          $ref: '#/components/responses/EventNullableResponse'
     delete:
       x-scope: public
       tags:
-       - EmergencyActionMessage
+        - Event
+      summary: Deletes an existing Event record.
       description: >-
-      summary: Deletes an existing EmergencyActionMessage record based on the provided ID.
-      operationId: DeleteEmergencyActionMessage
-      parameters:
-        - $ref: '#/components/parameters/ID'
+        Removes the event identified by the provided UID.
+      operationId: DeleteEvent
       responses:
         '200':
-          $ref: '#/components/responses/200EmergencyActionMessage_delete'
+          $ref: '#/components/responses/DeleteEventResponse'
+  /notifications/stream:
+    get:
+      x-scope: public
+      tags:
+        - Notifications
+      summary: Subscribe to EmergencyService notifications.
+      description: >-
+        Establishes a Server-Sent Events (SSE) stream that forwards unsolicited
+        LXMF notifications received by the gateway. Each event data payload is a
+        JSON document containing the notification title, decoded payload when
+        available, and the original payload encoded as Base64.
+      operationId: StreamNotifications
+      responses:
+        '200':
+          description: Stream of notification events in SSE format.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: >-
+                  SSE data frames containing JSON-encoded notification
+                  messages.
 components:
   schemas:
     EmergencyActionMessage:
-      allOf:
-        - type: object
-          properties:
-            callsign:
-              type: string
-              description: >-
-                use TAK or HAM callsign
-            groupName:
-              type: string
-              description: >-
-                 Number of people in the group (total number/number capable of defense)
-            commsMethod:
-              type: string
-              description: >-
-                comms Method Preferred (mobile phone, FRS, GMRS, MURS, simplex, repeater, etc.) Mark items with 1&#176;, 2&#176;, 3&#176;, etc. and write out the frequency, tones, modes, app names, or any other information necessary to make a contact using that comms method.
-            medicalStatus:
-              description: >-
-                Red – Injury / medical condition(s) requiring urgent attention ASAP
-                Yellow – Injury / medical condition(s) for which care can be delayed
-                Green – No injury / medical condition(s) requiring attention
-              $ref: '#/components/schemas/EAMStatus'
-            commsStatus:
-              description: >-
-                Red – No alternate comms available
-                Yellow – HT only
-                Green – Mobile (50watts) or better
-                Green + – Mobile (50watts or better), plus HF capability
-              $ref: '#/components/schemas/EAMStatus'
-            preparednessStatus:
-              description: >-
-                Red – No sustainment supplies…&lt;24 hrs.
-                Yellow – Limited sustainment supplies…&gt;24-72 hrs., but &lt;1 wk.
-                Green – Adequate sustainment supplies…&gt;1 week or better
-              $ref: '#/components/schemas/EAMStatus'
-            mobilityStatus:
-              description: >-
-                Red – Stuck at current location with no movement possible (May be due to injuries, vehicle status, security risks, kids/elderly unable to move)
-                Yellow – Can move by foot only
-                Green – Vehicular movement capable
-              $ref: '#/components/schemas/EAMStatus'
-            securityCapability:
-              description: >-
-                Red – No ability to repel threats
-                Yellow – Limited ability to repel threats (low on weapons/ammo/personnel)
-                Green – Full capacity to repel threats (adequate weapons/ammo/personnel)
-              $ref: '#/components/schemas/EAMStatus'
-            securityStatus:
-              description: >-
-                Red – Threats eminent
-                Yellow – No immediate threats, but NOT in a secure area
-                Green – No immediate threats and currently in a secure area
-              $ref: '#/components/schemas/EAMStatus'
-          required:
-            - callsign
-    Event:
-      allOf:
-        - type: object
-          properties:
-            uid:
-              type: integer
-              description: >-
-            how:
-              type: string
-              description: >-
-            version:
-              type: integer
-              description: >-
-            time:
-              type: integer
-              description: >-
-            type:
-              type: string
-              description: >-
-            stale:
-              type: string
-              description: >-
-            start:
-              type: string
-              description: >-
-            access:
-              type: string
-              description: >-
-            opex:
-              type: integer
-              description: >-
-            qos:
-              type: integer
-              description: >-
-            detail:
-              type: string
-              description: >-
-            point:
-              description: >-
-              nullable: true
-              type: string
-              x-reference: '#/components/schemas/Point'
-          required:
-            - uid
+      type: object
+      required:
+        - callsign
+      properties:
+        callsign:
+          type: string
+          description: >-
+            Callsign identifying the group. Use a TAK or HAM callsign.
+        groupName:
+          type: string
+          description: >-
+            Number of people in the group (total number/number capable of
+            defense).
+        commsMethod:
+          type: string
+          description: >-
+            Preferred communications method (mobile phone, FRS, GMRS, MURS,
+            simplex, repeater, etc.). Provide enough detail for recipients to
+            establish contact.
+        medicalStatus:
+          $ref: '#/components/schemas/EAMStatus'
+          description: >-
+            Red – Injury or medical condition(s) requiring urgent attention.
+            Yellow – Injury or medical condition(s) where care can be delayed.
+            Green – No injury requiring attention.
+        commsStatus:
+          $ref: '#/components/schemas/EAMStatus'
+          description: >-
+            Red – No alternate communications available.
+            Yellow – HT only.
+            Green – Mobile (50 watts) or better.
+            Green+ – Mobile (50 watts or better) plus HF capability.
+        preparednessStatus:
+          $ref: '#/components/schemas/EAMStatus'
+          description: >-
+            Red – No sustainment supplies (<24 hrs).
+            Yellow – Limited sustainment supplies (24–72 hrs but <1 week).
+            Green – Adequate sustainment supplies (>1 week).
+        mobilityStatus:
+          $ref: '#/components/schemas/EAMStatus'
+          description: >-
+            Red – Unable to move from current location.
+            Yellow – Can move by foot only.
+            Green – Vehicular movement capable.
+        securityCapability:
+          $ref: '#/components/schemas/EAMStatus'
+          description: >-
+            Red – No ability to repel threats.
+            Yellow – Limited ability to repel threats.
+            Green – Full capacity to repel threats.
+        securityStatus:
+          $ref: '#/components/schemas/EAMStatus'
+          description: >-
+            Red – Threats imminent.
+            Yellow – No immediate threats but not in a secure area.
+            Green – No immediate threats and currently in a secure area.
+    Detail:
+      type: object
+      properties:
+        emergencyActionMessage:
+          $ref: '#/components/schemas/EmergencyActionMessage'
+          description: >-
+            Embedded emergency action message providing situational context.
     Point:
-      allOf:
-        - type: object
-          properties:
-            lat:
-              type: number
-              description: >-
-            lon:
-              type: number
-              description: >-
-            ce:
-              type: number
-              description: >-
-            le:
-              type: number
-              description: >-
-            hae:
-              type: number
-              description: >-
+      type: object
+      properties:
+        lat:
+          type: number
+          format: double
+          description: Latitude in decimal degrees.
+        lon:
+          type: number
+          format: double
+          description: Longitude in decimal degrees.
+        ce:
+          type: number
+          format: double
+          description: Circular error value.
+        le:
+          type: number
+          format: double
+          description: Linear error value.
+        hae:
+          type: number
+          format: double
+          description: Height above ellipsoid.
+    Event:
+      type: object
+      required:
+        - uid
+      properties:
+        uid:
+          type: integer
+          description: Unique identifier for the event.
+        how:
+          type: string
+          description: Source of the event data.
+        version:
+          type: integer
+          description: Event version number.
+        time:
+          type: integer
+          description: Timestamp representing the event creation time.
+        type:
+          type: string
+          description: TAK event type value.
+        stale:
+          type: string
+          description: Time after which the event should be considered stale.
+        start:
+          type: string
+          description: Start timestamp for the event.
+        access:
+          type: string
+          description: Access control designation.
+        opex:
+          type: integer
+          description: Operational exercise indicator.
+        qos:
+          type: integer
+          description: Quality of service indicator.
+        detail:
+          $ref: '#/components/schemas/Detail'
+          description: Nested detail payload attached to the event.
+        point:
+          $ref: '#/components/schemas/Point'
+          description: Geographical point associated with the event.
+    DeleteEmergencyActionMessageResult:
+      type: object
+      required:
+        - status
+        - callsign
+      properties:
+        status:
+          type: string
+          description: Outcome of the delete operation.
+          enum:
+            - deleted
+            - not_found
+        callsign:
+          type: string
+          description: Callsign supplied to the delete request.
+    DeleteEventResult:
+      type: object
+      required:
+        - status
+        - uid
+      properties:
+        status:
+          type: string
+          description: Outcome of the delete operation.
+          enum:
+            - deleted
+            - not_found
+        uid:
+          type: integer
+          description: Event UID supplied to the delete request.
+    NotificationMessage:
+      type: object
+      properties:
+        title:
+          type: string
+          description: LXMF command title associated with the notification.
+        payload:
+          description: Decoded payload when available.
+          nullable: true
+        payload_raw:
+          type: string
+          format: byte
+          description: Base64 encoded payload bytes.
     Error:
       description: Error
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: integer
     EAMStatus:
+      type: string
+      description: Enumerated status values shared across EAM fields.
       enum:
         - Red
         - Yellow
         - Green
-      type: string
-      description: >-
   parameters:
-    ID:
-      name: id
+    EmergencyActionMessageCallsign:
+      name: callsign
       in: path
       required: true
-      description: >-
-        Identifier for the resource. For EmergencyActionMessage routes this is the
-        callsign string. For Event routes this maps to the numeric uid.
+      description: Callsign identifying the emergency action message.
       schema:
-        oneOf:
-          - type: string
-          - type: integer
-      
+        type: string
+    EventUID:
+      name: uid
+      in: path
+      required: true
+      description: Numeric identifier for the event record.
+      schema:
+        type: integer
   responses:
-    200Event_get:
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Event'
-    200EmergencyActionMessage_post:
-      description: Success
+    EmergencyActionMessageResponse:
+      description: Emergency action message payload.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/EmergencyActionMessage'
-    200EmergencyActionMessage_delete:
-      description: Success
+    EmergencyActionMessageNullableResponse:
+      description: Emergency action message payload or ``null`` when missing.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/EmergencyActionMessage'
-    200EmergencyActionMessage_get:
-      description: Success
+            allOf:
+              - $ref: '#/components/schemas/EmergencyActionMessage'
+            nullable: true
+    EmergencyActionMessageCollection:
+      description: List of emergency action messages.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/EmergencyActionMessage'
-    200EmergencyActionMessage_put:
-      description: Success
+            type: array
+            items:
+              $ref: '#/components/schemas/EmergencyActionMessage'
+    DeleteEmergencyActionMessageResponse:
+      description: Result of deleting an emergency action message.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/EmergencyActionMessage'
-    200Event_post:
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Event'
-    200Event_delete:
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Event'
-    200Event_put:
-      description: Success
+            $ref: '#/components/schemas/DeleteEmergencyActionMessageResult'
+    EventResponse:
+      description: Event payload.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Event'
+    EventNullableResponse:
+      description: Event payload or ``null`` when missing.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Event'
+            nullable: true
+    EventCollection:
+      description: List of events.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Event'
+    DeleteEventResponse:
+      description: Result of deleting an event.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DeleteEventResult'
     '200':
       description: OK
     '201':
@@ -384,7 +488,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-    'Error':
+    Error:
       description: Error
       content:
         application/json:
@@ -393,7 +497,8 @@ components:
   requestBodies:
     EmergencyActionMessage:
       description: >-
-        The Emergency Action Message (EAM) is a structured communication schema designed to provide essential situational awareness during critical incidents. It enables rapid assessment and secure reporting of a group's location, composition, security status, medical condition, preparedness level, mobility, and communication capabilities. By standardizing the relay of vital information, the EAM ensures clear and effective coordination in emergency response scenarios, enhancing decision-making and operational readiness within teams.
+        Emergency Action Message payload capturing a group's status,
+        communication posture, and preparedness details.
       content:
         application/json:
           schema:
@@ -401,31 +506,21 @@ components:
       required: true
     Event:
       description: >-
-        represents a simplified TAK event: this class is instantiated with a standard set of values.
-          The opex field is intended to indicate that the event is part of a   live operation, an exercise, or a simulation.  For backward compatibility, absence of the opex indicates "no statement", which will be interpreted in   an installation specific manner.
-          
-          opex="o-&lt;name&gt;" or "e-&lt;nickname&gt;"  or "s-&lt;nickname&gt;",
-          where "-&lt;name&gt;" is optional.  That is, it is permissible to   specify only "o", "e", or "s" for the opex value.
-        <ul>
-        	<li>  o = operations</li>
-        	<li>  e = exercise</li>
-        </ul>
-          s = simulation
+        Simplified TAK event payload containing optional nested detail and point
+        data.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Event'
       required: true
 x-uml-relationships:
-  
-  - name: "point"
+  - name: point
     x-ea-guid: 5013537E-3D0E-41c5-A6A7-B840C55224C2
     source:
-      schema: "#/components/schemas/Event"
-      multiplicity: "1..1"
+      schema: '#/components/schemas/Event'
+      multiplicity: 1..1
       navigability: Unspecified
     target:
-      schema: "#/components/schemas/Point"
-      multiplicity: "1..1"
+      schema: '#/components/schemas/Point'
+      multiplicity: 1..1
       navigability: Navigable
-

--- a/examples/EmergencyManagement/Server/models_emergency.py
+++ b/examples/EmergencyManagement/Server/models_emergency.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from typing import Union, Optional
+from typing import Any, Literal, Optional, Union
 
 from reticulum_openapi.model import BaseModel
 from sqlalchemy.orm import declarative_base
@@ -117,3 +117,22 @@ Vehicle = Union[Car, Bike]
 class TransportRecord(BaseModel):
     owner: str
     vehicle: Vehicle
+
+
+@dataclass
+class DeleteEmergencyActionMessageResult(BaseModel):
+    status: Literal["deleted", "not_found"]
+    callsign: str
+
+
+@dataclass
+class DeleteEventResult(BaseModel):
+    status: Literal["deleted", "not_found"]
+    uid: int
+
+
+@dataclass
+class NotificationMessage(BaseModel):
+    title: str
+    payload: Optional[Any] = None
+    payload_raw: Optional[str] = None


### PR DESCRIPTION
## Summary
- refresh the Emergency Management OpenAPI document with refined event/message paths, explicit collection/delete responses, and a notifications SSE stream
- document the richer schemas for nested detail/point payloads and delete outcomes
- hand-sync the Emergency Management models with new dataclasses matching the updated specification and log the work in TASK.md

## Testing
- openapi-spec-validator examples/EmergencyManagement/API/EmergencyActionMessageManagement-OAS.yaml

------
https://chatgpt.com/codex/tasks/task_e_68e3a31d99ac832588a601af3277d398