### PR TITLE
Normalize event detail storage with relational tables

### DIFF
--- a/examples/EmergencyManagement/Server/database.py
+++ b/examples/EmergencyManagement/Server/database.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import os
+import json
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
+from sqlalchemy import inspect, select
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -14,6 +16,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from .models_emergency import Base
+from .models_emergency import EventDetailORM, EventORM, EventPointORM
 
 
 DATABASE_ENV_VAR = "EMERGENCY_DATABASE_URL"
@@ -23,6 +26,90 @@ _DEFAULT_DATABASE_URL = f"sqlite+aiosqlite:///{_DEFAULT_DATABASE_PATH}"
 DATABASE_URL = _DEFAULT_DATABASE_URL
 engine: Optional[AsyncEngine] = None
 async_session: Optional[async_sessionmaker[AsyncSession]] = None
+
+
+def _load_json_if_string(value: Optional[str]) -> Optional[Any]:
+    """Return ``value`` decoded from JSON when represented as a string."""
+
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return value
+        return decoded
+    return value
+
+
+def _backfill_event_components(connection) -> None:
+    """Populate new event detail and point tables from legacy JSON columns."""
+
+    inspector = inspect(connection)
+    if "events" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("events")}
+    has_detail_column = "detail" in columns
+    has_point_column = "point" in columns
+
+    if not has_detail_column and not has_point_column:
+        return
+
+    detail_table = EventDetailORM.__table__
+    point_table = EventPointORM.__table__
+    event_table = EventORM.__table__
+
+    existing_detail = {
+        row[0]
+        for row in connection.execute(select(detail_table.c.event_uid))
+    }
+    existing_point = {
+        row[0]
+        for row in connection.execute(select(point_table.c.event_uid))
+    }
+
+    rows = connection.execute(
+        select(
+            event_table.c.uid,
+            event_table.c.detail_payload,
+            event_table.c.point_payload,
+        )
+    )
+
+    for uid, raw_detail, raw_point in rows:
+        if has_detail_column and uid not in existing_detail:
+            detail_payload = _load_json_if_string(raw_detail)
+            if isinstance(detail_payload, dict):
+                message_payload = _load_json_if_string(
+                    detail_payload.get("emergencyActionMessage")
+                )
+                connection.execute(
+                    detail_table.insert().values(
+                        event_uid=uid,
+                        emergencyActionMessage=message_payload,
+                    )
+                )
+                existing_detail.add(uid)
+
+        if has_point_column and uid not in existing_point:
+            point_payload = _load_json_if_string(raw_point)
+            if isinstance(point_payload, dict):
+                connection.execute(
+                    point_table.insert().values(
+                        event_uid=uid,
+                        lat=point_payload.get("lat"),
+                        lon=point_payload.get("lon"),
+                        ce=point_payload.get("ce"),
+                        le=point_payload.get("le"),
+                        hae=point_payload.get("hae"),
+                    )
+                )
+                existing_point.add(uid)
+
+
+def _apply_schema_upgrades(connection) -> None:
+    """Run schema upgrade routines for legacy deployments."""
+
+    _backfill_event_components(connection)
 
 
 def _normalise_database_url(candidate: Optional[str]) -> str:
@@ -121,6 +208,7 @@ async def init_db(url: Optional[str] = None) -> None:
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await conn.run_sync(_apply_schema_upgrades)
 
 
 # Initialise the module-level engine and session factory using the default

--- a/examples/EmergencyManagement/Server/models_emergency.py
+++ b/examples/EmergencyManagement/Server/models_emergency.py
@@ -1,10 +1,14 @@
-from dataclasses import dataclass
+"""Dataclasses and ORM models for the Emergency Management example."""
 
-from typing import Any, Literal, Optional, Union
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from typing import Any, Dict, Literal, Optional, Union
 
 from reticulum_openapi.model import BaseModel
-from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, Integer, String, JSON
+from sqlalchemy import Column, Float, ForeignKey, Integer, JSON, String
+from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
 
@@ -37,8 +41,51 @@ class EventORM(Base):
     access = Column(String, nullable=True)
     opex = Column(Integer, nullable=True)
     qos = Column(Integer, nullable=True)
-    detail = Column(JSON, nullable=True)
-    point = Column(JSON, nullable=True)
+    detail_payload = Column("detail", JSON, nullable=True)
+    point_payload = Column("point", JSON, nullable=True)
+
+    detail = relationship(
+        "EventDetailORM",
+        uselist=False,
+        back_populates="event",
+        cascade="all, delete-orphan",
+        lazy="joined",
+    )
+    point = relationship(
+        "EventPointORM",
+        uselist=False,
+        back_populates="event",
+        cascade="all, delete-orphan",
+        lazy="joined",
+    )
+
+
+class EventDetailORM(Base):
+    __tablename__ = "event_details"
+    event_uid = Column(
+        Integer,
+        ForeignKey("events.uid", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    emergencyActionMessage = Column(JSON, nullable=True)
+
+    event = relationship("EventORM", back_populates="detail", uselist=False)
+
+
+class EventPointORM(Base):
+    __tablename__ = "event_points"
+    event_uid = Column(
+        Integer,
+        ForeignKey("events.uid", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    lat = Column(Float, nullable=True)
+    lon = Column(Float, nullable=True)
+    ce = Column(Float, nullable=True)
+    le = Column(Float, nullable=True)
+    hae = Column(Float, nullable=True)
+
+    event = relationship("EventORM", back_populates="point", uselist=False)
 
 
 class EAMStatus(str):
@@ -64,6 +111,90 @@ class EmergencyActionMessage(BaseModel):
 @dataclass
 class Detail(BaseModel):
     emergencyActionMessage: Optional[EmergencyActionMessage] = None
+    __orm_model__ = EventDetailORM
+
+    @staticmethod
+    def _maybe_load_mapping(value: Any) -> Optional[Dict[str, Any]]:
+        """Return ``value`` as a mapping when possible."""
+
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            try:
+                decoded = json.loads(value)
+            except json.JSONDecodeError:
+                return None
+            if isinstance(decoded, dict):
+                return decoded
+            return None
+        return None
+
+    @staticmethod
+    def _coerce_emergency_action_message(
+        value: Any,
+    ) -> Optional[EmergencyActionMessage]:
+        """Convert ``value`` into an :class:`EmergencyActionMessage`."""
+
+        if value is None:
+            return None
+        if isinstance(value, EmergencyActionMessage):
+            return value
+        if isinstance(value, dict):
+            return EmergencyActionMessage(**value)
+        if isinstance(value, str):
+            try:
+                decoded = json.loads(value)
+            except json.JSONDecodeError:
+                return None
+            if isinstance(decoded, dict):
+                return EmergencyActionMessage(**decoded)
+        return None
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> Optional["Detail"]:
+        """Return a dataclass instance constructed from ``data``."""
+
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, EmergencyActionMessage):
+            return cls(emergencyActionMessage=data)
+        mapping = cls._maybe_load_mapping(data)
+        if mapping is None:
+            return None
+        payload = cls._coerce_emergency_action_message(
+            mapping.get("emergencyActionMessage")
+        )
+        return cls(emergencyActionMessage=payload)
+
+    @classmethod
+    def from_orm(cls, orm_obj: EventDetailORM) -> "Detail":
+        """Construct from an ORM payload."""
+
+        mapping: Dict[str, Any] = {
+            "emergencyActionMessage": getattr(orm_obj, "emergencyActionMessage"),
+        }
+        instance = cls.from_mapping(mapping)
+        return instance if instance is not None else cls(emergencyActionMessage=None)
+
+    def to_record(self) -> Dict[str, Any]:
+        """Return a serialisable mapping for persistence."""
+
+        payload = None
+        if isinstance(self.emergencyActionMessage, EmergencyActionMessage):
+            payload = asdict(self.emergencyActionMessage)
+        return {"emergencyActionMessage": payload}
+
+    def to_orm(self) -> EventDetailORM:
+        """Return the ORM payload associated with this dataclass."""
+
+        record = self.to_record()
+        return self.__orm_model__(
+            emergencyActionMessage=record.get("emergencyActionMessage")
+        )
 
 
 @dataclass
@@ -73,6 +204,79 @@ class Point(BaseModel):
     ce: Optional[float] = None
     le: Optional[float] = None
     hae: Optional[float] = None
+    __orm_model__ = EventPointORM
+
+    @staticmethod
+    def _coerce_float(value: Any) -> Optional[float]:
+        """Convert ``value`` into a ``float`` when possible."""
+
+        if value is None:
+            return None
+        if isinstance(value, float):
+            return value
+        if isinstance(value, int):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                return None
+        return None
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> Optional["Point"]:
+        """Return a dataclass instance constructed from ``data``."""
+
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, str):
+            try:
+                decoded = json.loads(data)
+            except json.JSONDecodeError:
+                return None
+            if isinstance(decoded, dict):
+                data = decoded
+            else:
+                return None
+        if not isinstance(data, dict):
+            return None
+        return cls(
+            lat=cls._coerce_float(data.get("lat")),
+            lon=cls._coerce_float(data.get("lon")),
+            ce=cls._coerce_float(data.get("ce")),
+            le=cls._coerce_float(data.get("le")),
+            hae=cls._coerce_float(data.get("hae")),
+        )
+
+    @classmethod
+    def from_orm(cls, orm_obj: EventPointORM) -> "Point":
+        """Construct from an ORM payload."""
+
+        return cls(
+            lat=cls._coerce_float(getattr(orm_obj, "lat", None)),
+            lon=cls._coerce_float(getattr(orm_obj, "lon", None)),
+            ce=cls._coerce_float(getattr(orm_obj, "ce", None)),
+            le=cls._coerce_float(getattr(orm_obj, "le", None)),
+            hae=cls._coerce_float(getattr(orm_obj, "hae", None)),
+        )
+
+    def to_record(self) -> Dict[str, Optional[float]]:
+        """Return a serialisable mapping for persistence."""
+
+        return {
+            "lat": self.lat,
+            "lon": self.lon,
+            "ce": self.ce,
+            "le": self.le,
+            "hae": self.hae,
+        }
+
+    def to_orm(self) -> EventPointORM:
+        """Return the ORM payload associated with this dataclass."""
+
+        return self.__orm_model__(**self.to_record())
 
 
 @dataclass
@@ -90,6 +294,122 @@ class Event(BaseModel):
     detail: Optional[Detail] = None
     point: Optional[Point] = None
     __orm_model__ = EventORM
+
+    @staticmethod
+    def _normalise_detail(raw_detail: Any) -> Optional[Detail]:
+        """Return a :class:`Detail` instance built from ``raw_detail``."""
+
+        return Detail.from_mapping(raw_detail)
+
+    @staticmethod
+    def _normalise_point(raw_point: Any) -> Optional[Point]:
+        """Return a :class:`Point` instance built from ``raw_point``."""
+
+        return Point.from_mapping(raw_point)
+
+    @classmethod
+    async def create(cls, session, **kwargs) -> "Event":
+        raw_detail = kwargs.pop("detail", None)
+        raw_point = kwargs.pop("point", None)
+
+        detail_obj = cls._normalise_detail(raw_detail)
+        point_obj = cls._normalise_point(raw_point)
+
+        orm_obj = cls.__orm_model__(**kwargs)
+
+        if detail_obj is not None:
+            orm_obj.detail = detail_obj.to_orm()
+            orm_obj.detail_payload = detail_obj.to_record()
+        else:
+            orm_obj.detail_payload = raw_detail
+
+        if point_obj is not None:
+            orm_obj.point = point_obj.to_orm()
+            orm_obj.point_payload = point_obj.to_record()
+        else:
+            orm_obj.point_payload = raw_point
+
+        session.add(orm_obj)
+        await session.commit()
+        await session.refresh(orm_obj)
+        return cls.from_orm(orm_obj)
+
+    @classmethod
+    async def update(cls, session, id_, **kwargs) -> Optional["Event"]:
+        raw_detail = kwargs.pop("detail", None)
+        raw_point = kwargs.pop("point", None)
+
+        orm_obj = await session.get(cls.__orm_model__, id_)
+        if orm_obj is None:
+            return None
+
+        for attr, value in kwargs.items():
+            setattr(orm_obj, attr, value)
+
+        if raw_detail is not None:
+            detail_obj = cls._normalise_detail(raw_detail)
+            if detail_obj is None:
+                orm_obj.detail = None
+            else:
+                if orm_obj.detail is None:
+                    orm_obj.detail = detail_obj.to_orm()
+                else:
+                    orm_obj.detail.emergencyActionMessage = detail_obj.to_record().get(
+                        "emergencyActionMessage"
+                    )
+            orm_obj.detail_payload = (
+                detail_obj.to_record() if detail_obj is not None else raw_detail
+            )
+
+        if raw_point is not None:
+            point_obj = cls._normalise_point(raw_point)
+            if point_obj is None:
+                orm_obj.point = None
+            else:
+                if orm_obj.point is None:
+                    orm_obj.point = point_obj.to_orm()
+                else:
+                    for attr, value in point_obj.to_record().items():
+                        setattr(orm_obj.point, attr, value)
+            orm_obj.point_payload = (
+                point_obj.to_record() if point_obj is not None else raw_point
+            )
+
+        session.add(orm_obj)
+        await session.commit()
+        await session.refresh(orm_obj)
+        return cls.from_orm(orm_obj)
+
+    @classmethod
+    def from_orm(cls, orm_obj: EventORM) -> "Event":
+        """Construct an :class:`Event` dataclass from an ORM instance."""
+
+        detail: Optional[Detail] = None
+        if getattr(orm_obj, "detail", None) is not None:
+            detail = Detail.from_orm(orm_obj.detail)
+        elif getattr(orm_obj, "detail_payload", None) is not None:
+            detail = Detail.from_mapping(orm_obj.detail_payload)
+
+        point: Optional[Point] = None
+        if getattr(orm_obj, "point", None) is not None:
+            point = Point.from_orm(orm_obj.point)
+        elif getattr(orm_obj, "point_payload", None) is not None:
+            point = Point.from_mapping(orm_obj.point_payload)
+
+        return cls(
+            uid=orm_obj.uid,
+            how=orm_obj.how,
+            version=orm_obj.version,
+            time=orm_obj.time,
+            type=orm_obj.type,
+            stale=orm_obj.stale,
+            start=orm_obj.start,
+            access=orm_obj.access,
+            opex=orm_obj.opex,
+            qos=orm_obj.qos,
+            detail=detail,
+            point=point,
+        )
 
 
 # --- Additional example models demonstrating allOf/oneOf/anyOf ---

--- a/examples/EmergencyManagement/web_gateway/app.py
+++ b/examples/EmergencyManagement/web_gateway/app.py
@@ -21,6 +21,7 @@ from typing import (
     Union,
     get_args,
     get_origin,
+    get_type_hints,
 )
 
 from importlib import metadata
@@ -425,9 +426,11 @@ def _build_dataclass(cls: Type[T], data: Dict[str, Any]) -> T:
         raise TypeError("Request payload must be a JSON object")
 
     kwargs: Dict[str, Any] = {}
+    type_hints = get_type_hints(cls)
     for field in fields(cls):
         if field.name in data:
-            kwargs[field.name] = _convert_value(field.type, data[field.name])
+            expected_type = type_hints.get(field.name, field.type)
+            kwargs[field.name] = _convert_value(expected_type, data[field.name])
     return cls(**kwargs)
 
 


### PR DESCRIPTION
## Summary
- add dedicated ORM mappings and dataclass helpers for event detail and point payloads
- backfill legacy JSON payloads into the new tables during database initialisation
- resolve forward references when building dataclasses in the web gateway

## Testing
- pytest tests/examples/emergency_management -q

------
https://chatgpt.com/codex/tasks/task_e_68e3ada3e1a8832597d102c1888ea1c5