### PR TITLE
Fix JSON dataclass decoding for postponed annotations

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -91,4 +91,5 @@
 ## 2025-10-06
 - [x] Add async EmergencyManagement controller handlers for new CRUD endpoints.
 - [x] Expand EmergencyManagement OpenAPI specification with notifications streaming and updated schemas.
+- [x] Resolve dataclass JSON decoding for postponed annotations in nested payloads.
 


### PR DESCRIPTION
## Summary
- resolve dataclass reconstruction for postponed annotations and optional nested payloads in the JSON/MessagePack helpers
- add regression coverage for optional nested dataclass decoding and document the work in TASK.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e41dea0e108325864bdcb74de46849