### PR TITLE
Add payload validation to emergency service routes

### DIFF
--- a/examples/EmergencyManagement/Server/service_emergency.py
+++ b/examples/EmergencyManagement/Server/service_emergency.py
@@ -1,3 +1,7 @@
+from typing import Any
+from typing import Dict
+from typing import Final
+
 from reticulum_openapi.service import LXMFService
 from examples.EmergencyManagement.Server.controllers_emergency import (
     EmergencyController,
@@ -7,6 +11,25 @@ from examples.EmergencyManagement.Server.models_emergency import (
     EmergencyActionMessage,
     Event,
 )
+
+
+_EAM_CALLSIGN_SCHEMA: Final[Dict[str, Any]] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Callsign identifying the emergency action message.",
+}
+
+_EVENT_IDENTIFIER_SCHEMA: Final[Dict[str, Any]] = {
+    "oneOf": [
+        {"type": "integer"},
+        {
+            "type": "string",
+            "pattern": r"^-?\\d+$",
+            "description": "Numeric identifier encoded as a string.",
+        },
+    ],
+    "description": "Unique identifier for the event record.",
+}
 
 
 class EmergencyService(LXMFService):
@@ -24,17 +47,33 @@ class EmergencyService(LXMFService):
             eamc.CreateEmergencyActionMessage,
             EmergencyActionMessage,
         )
-        self.add_route("DeleteEmergencyActionMessage", eamc.DeleteEmergencyActionMessage)
+        self.add_route(
+            "DeleteEmergencyActionMessage",
+            eamc.DeleteEmergencyActionMessage,
+            payload_schema=_EAM_CALLSIGN_SCHEMA,
+        )
         self.add_route("ListEmergencyActionMessage", eamc.ListEmergencyActionMessage)
         self.add_route(
             "PutEmergencyActionMessage",
             eamc.PutEmergencyActionMessage,
             EmergencyActionMessage,
         )
-        self.add_route("RetrieveEmergencyActionMessage", eamc.RetrieveEmergencyActionMessage)
+        self.add_route(
+            "RetrieveEmergencyActionMessage",
+            eamc.RetrieveEmergencyActionMessage,
+            payload_schema=_EAM_CALLSIGN_SCHEMA,
+        )
 
         self.add_route("CreateEvent", evc.CreateEvent, Event)
-        self.add_route("DeleteEvent", evc.DeleteEvent)
+        self.add_route(
+            "DeleteEvent",
+            evc.DeleteEvent,
+            payload_schema=_EVENT_IDENTIFIER_SCHEMA,
+        )
         self.add_route("ListEvent", evc.ListEvent)
         self.add_route("PutEvent", evc.PutEvent, Event)
-        self.add_route("RetrieveEvent", evc.RetrieveEvent)
+        self.add_route(
+            "RetrieveEvent",
+            evc.RetrieveEvent,
+            payload_schema=_EVENT_IDENTIFIER_SCHEMA,
+        )


### PR DESCRIPTION
## Summary
- add reusable JSON Schema definitions for emergency callsigns and event identifiers
- register the emergency and event controller commands with payload schemas so LXMF routing enforces validation

## Testing
- pytest tests/test_example_emergency_management.py -k "event_controller or emergency_action_message"

------
https://chatgpt.com/codex/tasks/task_e_68e5649ebe5483258a24c63148383ebc