### PR TITLE
Enhance emergency client helpers and documentation

### DIFF
--- a/examples/EmergencyManagement/README.md
+++ b/examples/EmergencyManagement/README.md
@@ -54,13 +54,30 @@ Both the CLI demo and the FastAPI gateway read [`client/client_config.json`](cli
   "request_timeout_seconds": 30,
   "lxmf_config_path": null,
   "lxmf_storage_path": null,
-  "shared_instance_rpc_key": "<hex rpc key>"
+  "shared_instance_rpc_key": "<hex rpc key>",
+  "generate_test_messages": false,
+  "enable_interactive_menu": true,
+  "test_message_count": 5,
+  "test_event_count": 5
 }
 ```
 
 - Override the location of the configuration file with `NORTH_API_CONFIG_PATH` or provide JSON directly through `NORTH_API_CONFIG_JSON`.
 - Requests can target different LXMF services by supplying an `X-Server-Identity` header or a `server_identity` query parameter to the gateway.
 - The repository ships with a sample Reticulum directory at [`examples/EmergencyManagement/.reticulum`](./.reticulum) that pins `rpc_key` to `F1E2D3C4B5A697887766554433221100`. When the gateway and LXMF service use this directory (or any config with the same key) they can attach to the same shared instance without prompting.
+
+| Key | Purpose |
+| --- | --- |
+| `server_identity_hash` | Destination LXMF identity hash for the Emergency service. |
+| `client_display_name` | Friendly name announced by the LXMF client. |
+| `request_timeout_seconds` | Timeout applied to each LXMF command issued by the client or gateway. |
+| `lxmf_config_path` | Optional override for the Reticulum configuration directory. |
+| `lxmf_storage_path` | Optional override for the LXMF storage directory. |
+| `shared_instance_rpc_key` | RPC key used when attaching to a shared Reticulum instance. |
+| `generate_test_messages` | When `true`, the CLI seeds random emergency messages and events during startup. |
+| `enable_interactive_menu` | Enables the interactive CLI menu after the initial demo run. Disable when scripting automated flows. |
+| `test_message_count` | Number of emergency messages to seed when `generate_test_messages` is enabled. |
+| `test_event_count` | Number of events to seed when `generate_test_messages` is enabled. |
 
 ### Web UI environment
 
@@ -90,7 +107,7 @@ Copy [`webui/.env.example`](webui/.env.example) to `webui/.env` and set:
    python client/client_emergency.py
    ```
 
-   The client reuses the stored identity hash (or prompts for one), sends a `CreateEmergencyActionMessage` command, and then retrieves the stored record to verify persistence in `emergency.db`.
+   The client reuses the stored identity hash (or prompts for one) and exposes an interactive menu for creating, listing, updating, retrieving, and deleting emergency action messages over LXMF.
 
 3. **Expose the REST gateway**
 

--- a/examples/EmergencyManagement/client/README.md
+++ b/examples/EmergencyManagement/client/README.md
@@ -1,3 +1,16 @@
 # Emergency Management northbound client
 
-The full stack setup—including the shared LXMF client, FastAPI gateway, and CLI demo—is documented in the consolidated [Emergency Management README](../README.md). Refer to that guide for configuration values, startup commands, and build instructions. The sample [`client_config.json`](client_config.json) now also includes a `shared_instance_rpc_key` entry so the CLI, web gateway, and LXMF service can all authenticate with the bundled Reticulum configuration under [`../.reticulum`](../.reticulum).
+The full stack setup—including the shared LXMF client, FastAPI gateway, and CLI demo—is documented in the consolidated [Emergency Management README](../README.md). Refer to that guide for configuration values, startup commands, and build instructions. The CLI now presents an interactive menu that lets operators:
+
+- create new emergency action messages,
+- update existing records,
+- list all stored messages,
+- retrieve individual messages by callsign, and
+- delete records when they are no longer needed.
+
+All operations use the shared LXMF client and message codecs, so the CLI mirrors the behaviour of the gateway and northbound API. Populate [`client_config.json`](client_config.json) with values that match your mesh. In addition to the LXMF configuration paths and RPC key, the client understands:
+
+- `request_timeout_seconds` – per-command timeout budget,
+- `generate_test_messages` – optional seeding of random demo data,
+- `enable_interactive_menu` – turn the interactive prompt on or off (useful for automation),
+- `test_message_count` / `test_event_count` – payload counts for the seeding routine.

--- a/examples/EmergencyManagement/client/client_config.json
+++ b/examples/EmergencyManagement/client/client_config.json
@@ -5,5 +5,8 @@
   "lxmf_config_path": null,
   "lxmf_storage_path": null,
   "generate_test_messages": true,
-  "shared_instance_rpc_key": "F1E2D3C4B5A697887766554433221100"
+  "enable_interactive_menu": true,
+  "shared_instance_rpc_key": "F1E2D3C4B5A697887766554433221100",
+  "test_message_count": 5,
+  "test_event_count": 5
 }


### PR DESCRIPTION
## Summary
- add decode helpers and command constants for the new emergency action message APIs
- extend the emergency CLI with an interactive menu that exercises the new helpers and optional data seeding
- document the additional client configuration keys and update the sample config

## Testing
- pytest tests/test_example_emergency_management.py

------
https://chatgpt.com/codex/tasks/task_e_68e567eaba9c83258cc5fd9a72d605fa