### PR TITLE
Improve EmergencyManagement gateway dataclass handling

### DIFF
--- a/tests/examples/emergency_management/test_web_gateway.py
+++ b/tests/examples/emergency_management/test_web_gateway.py
@@ -284,7 +284,7 @@ def test_delete_event_sends_identifier_string(gateway_app) -> None:
     )
 
     assert response.status_code == 200
-    assert response.json() == {"status": "deleted", "uid": "21"}
+    assert response.json() == {"status": "deleted", "uid": 21}
 
     args, _ = stub.send_command.await_args
     assert args[0] == SERVER_IDENTITY
@@ -296,7 +296,7 @@ def test_list_events_decodes_compressed_json(gateway_app) -> None:
     """Compressed JSON responses should be decompressed and parsed."""
 
     _module, client, stub = gateway_app
-    payload = {"items": [{"uid": 1, "point": {"lat": 12.5}}]}
+    payload = [{"uid": 1, "point": {"lat": 12.5}}]
     stub.send_command.return_value = zlib.compress(json.dumps(payload).encode("utf-8"))
 
     response = client.get(


### PR DESCRIPTION
## Summary
- add command specifications in the EmergencyManagement gateway so each REST route converts request payloads into the correct LXMF dataclasses and expects typed responses
- normalise decoded LXMF replies by coercing primitives, rebuilding dataclasses, and serialising them back to JSON-safe structures
- align the web gateway tests with the typed delete response and compressed list payload handling

## Testing
- pytest tests/examples/emergency_management/test_web_gateway.py

------
https://chatgpt.com/codex/tasks/task_e_68e572559eec83258f3035c4af41eb94