### PR TITLE
Fix missing blank lines before main in emergency client CLI

### DIFF
--- a/examples/EmergencyManagement/client/client_emergency.py
+++ b/examples/EmergencyManagement/client/client_emergency.py
@@ -562,6 +562,8 @@ async def _interactive_loop(
             await _handle_delete_message(client, server_identity)
         else:
             print("Unrecognised option. Please choose again.")
+
+
 async def main():
     """Run the interactive Emergency Management CLI."""
 


### PR DESCRIPTION
## Summary
- add the required blank lines before the emergency client main entrypoint to satisfy flake8 E302

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e575956960832595a09e972fa0709e