### PR TITLE
docs: document emergency management CLI and template updates

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -93,3 +93,8 @@
 - [x] Expand EmergencyManagement OpenAPI specification with notifications streaming and updated schemas.
 - [x] Resolve dataclass JSON decoding for postponed annotations in nested payloads.
 
+## 2025-10-07
+- [x] Document EmergencyManagement LXMF command catalogue, service CLI overrides, and gateway deployment settings across
+  READMEs.
+- [x] Update Mustache template guidance to cover long-running services, database overrides, and shared client configuration.
+

--- a/examples/EmergencyManagement/client/README.md
+++ b/examples/EmergencyManagement/client/README.md
@@ -8,6 +8,11 @@ The full stack setup—including the shared LXMF client, FastAPI gateway, and CL
 - retrieve individual messages by callsign, and
 - delete records when they are no longer needed.
 
+Behind the scenes the client issues the same LXMF commands as the gateway. Emergency action message flows map to
+`CreateEmergencyActionMessage`, `PutEmergencyActionMessage`, `ListEmergencyActionMessage`, `RetrieveEmergencyActionMessage`,
+and `DeleteEmergencyActionMessage`. Test seeding also exercises the event catalogue (`CreateEvent`, `PutEvent`, `ListEvent`,
+`RetrieveEvent`, and `DeleteEvent`) so the mesh service contains representative data for the web UI.
+
 All operations use the shared LXMF client and message codecs, so the CLI mirrors the behaviour of the gateway and northbound API. Populate [`client_config.json`](client_config.json) with values that match your mesh. In addition to the LXMF configuration paths and RPC key, the client understands:
 
 - `request_timeout_seconds` – per-command timeout budget,

--- a/templates/README.md
+++ b/templates/README.md
@@ -44,5 +44,19 @@ Adjust the generated code as needed for your specification.
 
 - Set `auth_token` on the generated service and client if your deployment
   requires message authentication.
+- Extend the generated `server.py` with the same runtime CLI options used by
+  the Emergency Management example (`--config-path`, `--storage-path`,
+  `--display-name`, `--auth-token`, `--database-path`, `--database-url`, and
+  `--link-keepalive-interval`). The scaffolded file only sleeps for 30 seconds;
+  update it to wait on a signal-aware shutdown event so the service keeps
+  running until interrupted, prints its identity hashes, and retries LXMF link
+  establishment when necessary.
+- Call `configure_database()` with a caller-supplied override before `init_db`
+  to honour environment variables such as `EMERGENCY_DATABASE_URL` or CLI
+  flags.
 - Add additional schema dataclasses if your API defines objects outside the
   supplied OpenAPI spec.
+- Mirror the gateway helpers if you need FastAPI adapters: load shared LXMF
+  client configuration from `NORTH_API_CONFIG_PATH`/`NORTH_API_CONFIG_JSON`,
+  expose `/notifications/stream`, and surface interface or link status in
+  startup logs.


### PR DESCRIPTION
## Summary
- document the Emergency Management LXMF command catalogue and new service CLI/runtime knobs
- expand client and gateway README guidance for configuration overrides and deployment logging
- capture template follow-ups and task tracking updates for long-running services and database overrides

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e575cd5aac83259a01b26b100f4452